### PR TITLE
Enabled Prefect, Tiled, app, and worker job to run in Docker

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,7 +40,7 @@ SUBMISSION_SSH_KEY="~/.ssh/id_rsa"
 FORWARD_PORTS='["8888:8888"]'
 
 MODE="deployment"
-DOCKER_NETWORK="mlex_latent_explorer_mle_net"
+DOCKER_NETWORK="mle_net"
 
 #WEBSOCKET
 WEBSOCKET_PORT=8765

--- a/.env.example
+++ b/.env.example
@@ -1,12 +1,24 @@
+TILED_SINGLE_USER_API_KEY=<unique api key>
+
+PREFECT_DB_PW=<unique password>
+PREFECT_DB_USER=prefect_user
+PREFECT_DB_NAME=prefect
+PREFECT_DB_SERVER=prefect_db
+
+TILED_DB_PW=<unique password>
+TILED_DB_USER=tiled_user
+TILED_DB_NAME=tiled
+TILED_DB_SERVER=tiled_db
+
 # Directories
 READ_DIR=/path/to/read/data
 WRITE_DIR=/path/to/write/results
 
 # Default Tiled setup
-DEFAULT_TILED_URI=http://tiled:8888
+DEFAULT_TILED_URI=http://tiled:8000
 DEFAULT_TILED_SUB_URI=
 DATA_TILED_KEY=<your_data_tiled_key>
-RESULTS_TILED_URI=http://tiled:8888
+RESULTS_TILED_URI=http://tiled:8000
 RESULTS_TILED_API_KEY=<your_results_tiled_key>
 
 # Prefect
@@ -14,7 +26,7 @@ PREFECT_API_URL=http://prefect:4200/api
 FLOW_NAME="Parent flow/launch_parent_flow"
 TIMEZONE="US/Pacific"
 PREFECT_TAGS='["latent-space-explorer"]'
-FLOW_TYPE="conda"
+FLOW_TYPE="docker"
 
 # Slurm jobs
 PARTITIONS_CPU='["p_cpu1", "p_cpu2"]'
@@ -28,6 +40,7 @@ SUBMISSION_SSH_KEY="~/.ssh/id_rsa"
 FORWARD_PORTS='["8888:8888"]'
 
 MODE="deployment"
+DOCKER_NETWORK="mlex_latent_explorer_mle_net"
 
 #WEBSOCKET
 WEBSOCKET_PORT=8765

--- a/.gitignore
+++ b/.gitignore
@@ -11,13 +11,7 @@ test.py
 
 # output dir
 results/
-data/output/
-data/upload/
-data/.file_manager_vars.pkl
-data/mlexchange_store/
-data/prefect_db/
-data/tiled_db/
-data/tiled_storage/
+data/
 .DS_Store
 
 # C extensions

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ data/output/
 data/upload/
 data/.file_manager_vars.pkl
 data/mlexchange_store/
+data/prefect_db/
+data/tiled_db/
+data/tiled_storage/
 .DS_Store
 
 # C extensions

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ RUN pip install .
 
 ENV HOME /app/work
 
-CMD ["gunicorn", "-c", "gunicorn_config.py", "--reload", "src.app_layout:server"]
+CMD ["python", "frontend.py"]

--- a/README.md
+++ b/README.md
@@ -1,28 +1,67 @@
 # MLExchange Latent Space Explorer
 
-An app to visulize latent vectors in 2D or 3D. It supports PCA and UMAP for dimension reduction.
+An application for visualizing latent vectors in **2D or 3D** using **PCA** and **UMAP** for dimensionality reduction.
 
-## Running as a standalone application
+## Running as a Standalone Application (Using Docker)
 
-1. The **Prefect server, Tiled server, the application, and the Prefect worker job** all run within a single Docker container. There is no need to start the servers separately. However, the **Prefect worker** should be run separately on your PC. Refer to [mlex_prefect_worker](https://github.com/mlexchange/mlex_prefect_worker) for instructions on running the Prefect worker.
+The **Prefect server, Tiled server, the application, and the Prefect worker job** all run within a **single Docker container**. This eliminates the need to start the servers separately.
 
+However, the **Prefect worker** must be run separately on your local machine (refer to step 5). 
 
-2. Create a new Python environment and install dependencies:
-```
-conda create -n new_env python==3.11
-conda activate new_env
-pip install .
-```
+## Steps to Run the Application
 
-3. Create a `.env` file using `.env.example` as reference. Update this file accordingly.
+### 1️ Clone the Repository
 
-4. Start example app:
-```
-docker comnpose up
+```sh
+git clone https://github.com/mlexchange/mlex_latent_explorer.git
+cd mlex_latent_explorer
 ```
 
-Finally, you can access Latent Space Explorer at:
-* Dash app: http://localhost:8070/
+### 2️ Configure Environment Variables
+
+Create a `.env` file using `.env.example` as a reference:
+
+```sh
+cp .env.example .env
+```
+
+Then **update the** `.env` file with the correct values.
+
+**Important Note:** Due to the current tiled configuration, ensure that the `WRITE_DIR` is a subdirectory of the `READ_DIR` if the same tiled server is used for both reading data and writing results.
+
+### 3️ Build and Start the Application
+
+```sh
+docker compose up -d
+```
+
+* `-d` → Runs the containers in the background (detached mode).
+
+### 4️ Verify Running Containers
+
+```sh
+docker ps
+```
+
+### 5️ Start a Prefect Worker
+
+Open another terminal and start a Prefect worker. Refer to [mlex_prefect_worker](https://github.com/mlexchange/mlex_prefect_worker) for detailed instructions on setting up and running the worker.
+
+
+### 6 Access the Application
+
+Once the container is running, open your browser and visit:
+* **Dash app:** http://localhost:8070/
+
+### 7 Stopping the Application
+
+To stop and remove the running containers, use:
+
+```sh
+docker compose down
+```
+
+This will **shut down all services** but **retain data** if volumes are used.
 
 ## Model Description
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ An app to visulize latent vectors in 2D or 3D. It supports PCA and UMAP for dime
 
 ## Running as a standalone application
 
-1. Start a Tiled and Prefect servers in the [MLExchange platform](https://github.com/mlexchange/mlex_tomo_framework). Before moving to the next step, please make sure that both services are running accordingly.
+1. The **Prefect server, Tiled server, the application, and the Prefect worker job** all run within a single Docker container. There is no need to start the servers separately. However, the **Prefect worker** should be run separately on your PC. Refer to [mlex_prefect_worker](https://github.com/mlexchange/mlex_prefect_worker) for instructions on running the Prefect worker.
+
 
 2. Create a new Python environment and install dependencies:
 ```
@@ -17,7 +18,7 @@ pip install .
 
 4. Start example app:
 ```
-python frontend.py
+docker comnpose up
 ```
 
 Finally, you can access Latent Space Explorer at:

--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@ However, the **Prefect worker** must be run separately on your local machine (re
 
 ## Steps to Run the Application
 
-### 1️ Clone the Repository
+### 1 Clone the Repository
 
 ```sh
 git clone https://github.com/mlexchange/mlex_latent_explorer.git
 cd mlex_latent_explorer
 ```
 
-### 2️ Configure Environment Variables
+### 2 Configure Environment Variables
 
 Create a `.env` file using `.env.example` as a reference:
 
@@ -29,7 +29,7 @@ Then **update the** `.env` file with the correct values.
 
 **Important Note:** Due to the current tiled configuration, ensure that the `WRITE_DIR` is a subdirectory of the `READ_DIR` if the same tiled server is used for both reading data and writing results.
 
-### 3️ Build and Start the Application
+### 3 Build and Start the Application
 
 ```sh
 docker compose up -d
@@ -37,13 +37,13 @@ docker compose up -d
 
 * `-d` → Runs the containers in the background (detached mode).
 
-### 4️ Verify Running Containers
+### 4 Verify Running Containers
 
 ```sh
 docker ps
 ```
 
-### 5️ Start a Prefect Worker
+### 5 Start a Prefect Worker
 
 Open another terminal and start a Prefect worker. Refer to [mlex_prefect_worker](https://github.com/mlexchange/mlex_prefect_worker) for detailed instructions on setting up and running the worker.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -115,4 +115,5 @@ services:
 
 networks:
   mle_net:
+    name: mle_net
     driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
       - TILED_SINGLE_USER_API_KEY=${TILED_SINGLE_USER_API_KEY}
     volumes:
       - ./tiled/deploy:/deploy
-      - ./data/tiled_storage:/tiled_storage
+      - ${READ_DIR}:/tiled_storage
     depends_on:
       - tiled_db
     networks:
@@ -58,7 +58,7 @@ services:
       - POSTGRES_DB=${TILED_DB_NAME}
     volumes:
       - ./data/tiled_db:/var/lib/postgresql/data:rw
-      - ./data/tiled_storage:/tiled_storage
+      - ${READ_DIR}:/tiled_storage
     restart: unless-stopped
     networks:
       mle_net:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,74 @@
 version: "3"
 
 services:
+  prefect:
+    image: prefecthq/prefect:2.14-python3.11
+    command: prefect server start
+    environment:
+      - PREFECT_SERVER_API_HOST=0.0.0.0
+      - PREFECT_API_DATABASE_CONNECTION_URL=postgresql+asyncpg://${PREFECT_DB_USER}:${PREFECT_DB_PW}@prefect_db:5432/${PREFECT_DB_NAME} # Needed if using postgres and not sqlite
+      # - PREFECT_UI_API_URL=https://localhost/api. needed if nginx is handling ssl termination
+      - PREFECT_LOGGING_LEVEL=DEBUG
+    ports:
+      - "127.0.0.1:4200:4200"
+    depends_on:
+      - prefect_db
+    networks:
+      mle_net:
+
+
+  prefect_db:
+    image: postgres:14.5-alpine
+    environment:
+      - POSTGRES_USER=${PREFECT_DB_USER}
+      - POSTGRES_PASSWORD=${PREFECT_DB_PW}
+      - POSTGRES_DB=${PREFECT_DB_NAME}
+    volumes:
+      - ./data/prefect_db:/var/lib/postgresql/data:rw
+    restart: unless-stopped
+    networks:
+      mle_net:
+
+
+  tiled:
+    # see the file ./tiled/deploy/config.yml for detailed configuration of tiled
+    image: ghcr.io/bluesky/tiled:v0.1.0a118
+    ports:
+      - "127.0.0.1:8000:8000"
+    environment:
+      - TILED_DB_USER=${TILED_DB_USER}
+      - TILED_DB_PW=${TILED_DB_PW}
+      - TILED_DB_NAME=${TILED_DB_NAME}
+      - TILED_DB_SERVER=${TILED_DB_SERVER}
+      - TILED_SINGLE_USER_API_KEY=${TILED_SINGLE_USER_API_KEY}
+    volumes:
+      - ./tiled/deploy:/deploy
+      - ./data/tiled_storage:/tiled_storage
+    depends_on:
+      - tiled_db
+    networks:
+      mle_net:
+
+
+  tiled_db:
+    image: postgres:14.5-alpine
+    environment:
+      - POSTGRES_USER=${TILED_DB_USER}
+      - POSTGRES_PASSWORD=${TILED_DB_PW}
+      - POSTGRES_DB=${TILED_DB_NAME}
+    volumes:
+      - ./data/tiled_db:/var/lib/postgresql/data:rw
+      - ./data/tiled_storage:/tiled_storage
+    restart: unless-stopped
+    networks:
+      mle_net:
 
   front-end:
     restart: "unless-stopped"
     container_name: "latentxp"
     build:
       context: "."
+    command: "python frontend.py"
     environment:
       # Dash
       APP_HOST: "0.0.0.0"
@@ -14,8 +76,8 @@ services:
       # Data directories
       READ_DIR_MOUNT: "${READ_DIR}"   # Used to mount the read directory in podman jobs
       WRITE_DIR_MOUNT: "${WRITE_DIR}" # Used to mount the write directory in podman jobs
-      READ_DIR: "/app/work/data"
-      WRITE_DIR: "/app/work/mlex_store"
+      READ_DIR: "/tiled_storage"
+      WRITE_DIR: "/tiled_storage/writable"
       # Tiled
       DEFAULT_TILED_URI: '${DEFAULT_TILED_URI}'
       DATA_TILED_KEY: '${DATA_TILED_KEY}'
@@ -27,6 +89,7 @@ services:
       TIMEZONE: "${TIMEZONE}"
       PREFECT_TAGS: "${PREFECT_TAGS}"
       FLOW_TYPE: "${FLOW_TYPE}"
+      DOCKER_NETWORK: "${DOCKER_NETWORK}"
       # Slurm jobs
       PARTITIONS_CPU: "${PARTITIONS_CPU}"
       MAX_TIME_CPU: "${MAX_TIME_CPU}"
@@ -43,13 +106,13 @@ services:
       WEBSOCKET_URL: ${WEBSOCKET_URL}
       WEBSOCKET_PORT: ${WEBSOCKET_PORT}
     volumes:
-      - ${READ_DIR}:/app/work/data
-      - ${WRITE_DIR}:/app/work/mlex_store
+      - ${READ_DIR}:/tiled_storage
+      - ./src:/app/work/src
     ports:
       - "127.0.0.1:8070:8070"
     networks:
-      mlex_tomo_framework_mle_net:
+      mle_net:
 
 networks:
-  mlex_tomo_framework_mle_net:
-    external: true
+  mle_net:
+    driver: bridge

--- a/src/assets/default_models.json
+++ b/src/assets/default_models.json
@@ -129,7 +129,7 @@
                 "param_key": "n_neighbors"
             }
         ],
-        "python_file_name": "mlex_dimension_reduction_umap/src/umap_run.py",
+        "python_file_name": "src/umap_run.py",
         "public": false
         },
         {
@@ -163,7 +163,7 @@
                 "param_key": "n_components"
             }
         ],
-        "python_file_name": "mlex_dimension_reduction_pca/src/pca_run.py",
+        "python_file_name": "src/pca_run.py",
         "public": false
         },
         {
@@ -187,7 +187,7 @@
                 "param_key": "n_clusters"
             }
         ],
-        "python_file_name": "mlex_clustering/src/clustering_kmeans.py",
+        "python_file_name": "src/clustering_kmeans.py",
         "public": false
         },
         {
@@ -218,7 +218,7 @@
                 "param_key": "min_samples"
             }
         ],
-        "python_file_name": "mlex_clustering/src/clustering_dbscan.py",
+        "python_file_name": "src/clustering_dbscan.py",
         "public": false
         },
         {
@@ -242,7 +242,7 @@
                 "param_key": "min_cluster_size"
             }
         ],
-        "python_file_name": "mlex_clustering/src/clustering_hdbscan.py",
+        "python_file_name": "src/clustering_hdbscan.py",
         "public": false
         }
     ]

--- a/src/utils/job_utils.py
+++ b/src/utils/job_utils.py
@@ -65,29 +65,9 @@ def parse_job_params(
         "results_dir": f"{results_dir}",
     }
 
-    if flow_type == "podman":
+    if flow_type == "podman" or flow_type == "docker":
         job_params = {
-            "flow_type": "podman",
-            "params_list": [
-                {
-                    "image_name": image_name,
-                    "image_tag": image_tag,
-                    "command": f'python {python_file_name}',
-                    "params": {
-                        "io_parameters": io_parameters,
-                        "model_parameters": model_parameters,
-                    },
-                    "volumes": [
-                        f"{READ_DIR_MOUNT}:/app/work/data",
-                        f"{WRITE_DIR_MOUNT}:/app/work/mlex_store",
-                    ],
-                }
-            ],
-        }
-
-    elif flow_type == "docker":
-        job_params = {
-            "flow_type": "docker",
+            "flow_type": flow_type,
             "params_list": [
                 {
                     "image_name": image_name,

--- a/src/utils/job_utils.py
+++ b/src/utils/job_utils.py
@@ -18,7 +18,7 @@ RESERVATIONS_GPU = json.loads(os.getenv("RESERVATIONS_CPU", "[]"))
 MAX_TIME_GPU = os.getenv("MAX_TIME_CPU", "1:00:00")
 SUBMISSION_SSH_KEY = os.getenv("SUBMISSION_SSH_KEY", "")
 FORWARD_PORTS = json.loads(os.getenv("FORWARD_PORTS", "[]"))
-
+DOCKER_NETWORK=os.getenv("DOCKER_NETWORK", "")
 FLOW_TYPE = os.getenv("FLOW_TYPE", "conda")
 
 
@@ -72,7 +72,7 @@ def parse_job_params(
                 {
                     "image_name": image_name,
                     "image_tag": image_tag,
-                    "command": f'python {python_file_name}"',
+                    "command": f'python {python_file_name}',
                     "params": {
                         "io_parameters": io_parameters,
                         "model_parameters": model_parameters,
@@ -81,6 +81,27 @@ def parse_job_params(
                         f"{READ_DIR_MOUNT}:/app/work/data",
                         f"{WRITE_DIR_MOUNT}:/app/work/mlex_store",
                     ],
+                }
+            ],
+        }
+
+    elif flow_type == "docker":
+        job_params = {
+            "flow_type": "docker",
+            "params_list": [
+                {
+                    "image_name": image_name,
+                    "image_tag": image_tag,
+                    "command": f'python {python_file_name}',
+                    "params": {
+                        "io_parameters": io_parameters,
+                        "model_parameters": model_parameters,
+                    },
+                    "volumes": [
+                        f"{READ_DIR_MOUNT}:/tiled_storage",
+                       
+                    ],
+                    "network":DOCKER_NETWORK
                 }
             ],
         }

--- a/tiled/deploy/config/config.yml
+++ b/tiled/deploy/config/config.yml
@@ -1,0 +1,28 @@
+authentication:
+  # The default is false. Set to true to enable any HTTP client that can
+  # connect to _read_. An API key is still required to write.
+  allow_anonymous_access: true
+  single_user_api_key: ${TILED_SINGLE_USER_API_KEY}
+trees:
+  - path: /
+    tree: catalog
+    args:
+      uri: "postgresql+asyncpg://${TILED_DB_USER}:${TILED_DB_PW}@${TILED_DB_SERVER}:5432/${TILED_DB_NAME}"
+      readable_storage: ["/tiled_storage"]
+      writable_storage: "/tiled_storage/writable"
+      # This creates the database if it does not exist. This is convenient, but in
+      # a horizonally-scaled deployment, this can be a race condition and multiple
+      # containers may simultanouesly attempt to create the database.
+      # If that is a problem, set this to false, and run:
+      #
+      # tiled catalog init URI
+      #
+      # separately.
+      init_if_not_exists: true
+uvicorn:
+  host: 0.0.0.0
+  port: 8000
+object_cache:
+  available_bytes: 0
+metrics: 
+  prometheus: false


### PR DESCRIPTION
## Description  
This update ensures that Prefect, Tiled, the application, and the Prefect worker job all run within a Docker container, while the Prefect worker runs separately on the PC. This implementation is compatible with [Pull Request #24 of `mlex_prefect_worker`](https://github.com/mlexchange/mlex_prefect_worker/pull/24), which adds support for running jobs inside a Docker container.  

## Key Changes  
- **Modify `.env.example`**: Add variables `PREFECT_DB_XX`, `TILED_DB_XX`, and `DOCKER_NETWORK`.  
- **Modify `docker-compose.yml`**:  
  - Add new services: `prefect`, `prefect_db`, `tiled`, and `tiled_db`.  
  - Update front-end service:  
    - Add `command`.  
    - Modify environment variables: add `DOCKER_NETWORK`, update `READ_DIR` and `WRITE_DIR`.  
    - Update volumes.  
  - Update networks: change name and driver.  
- **Modify `job_utils.py`**:  
  - Add support for `flow_type == "docker"` in `parse_job_params()`.  
  - Remove extra `"` in `command` for `flow_type == "podman"` (typo fix).  
- **Modify `default_models.json`**: Update `python_file_name` for all models (umap, pca, etc.).  
- **Add `config.yml`** for Tiled.  
- **Update `README.md`** to reflect the changes.  
- **Update `.gitignore`**: Add `data/prefect_db/`, `data/tiled_db/`, and `data/tiled_storage/`.  

## Related PRs / Issues  
- Related to [PR #24 in `mlex_prefect_worker`](https://github.com/mlexchange/mlex_prefect_worker/pull/24).  

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209575866336856