### PR TITLE
Move buffer, data project and indices clientside

### DIFF
--- a/frontend.py
+++ b/frontend.py
@@ -33,7 +33,6 @@ from src.callbacks.infrastructure_check import (  # noqa: F401
     update_infra_state,
 )
 from src.callbacks.live_mode import (  # noqa: F401
-    set_buffered_latent_vectors,
     set_live_latent_vectors,
     toggle_controls,
     toggle_pause_button,

--- a/frontend.py
+++ b/frontend.py
@@ -5,7 +5,7 @@ from uuid import uuid4
 from dash import Input, Output, html
 from dotenv import load_dotenv
 
-from src.app_layout import app, clustering_models, dim_reduction_models, mlex_components,latent_space_models
+from src.app_layout import app, clustering_models, dim_reduction_models, mlex_components
 from src.callbacks.display import (  # noqa: F401
     clear_selections,
     disable_buttons,
@@ -23,17 +23,16 @@ from src.callbacks.execute import (  # noqa: F401
     allow_run_clustering,
     allow_show_clusters,
     allow_show_feature_vectors,
+    load_mlflow_models_on_render,
+    refresh_mlflow_models,
     run_clustering,
     run_latent_space,
-    refresh_mlflow_models,
-    load_mlflow_models_on_render
 )
 from src.callbacks.infrastructure_check import (  # noqa: F401
     check_infra_state,
     update_infra_state,
 )
 from src.callbacks.live_mode import (  # noqa: F401
-    live_update_data_project_dict,
     set_buffered_latent_vectors,
     set_live_latent_vectors,
     toggle_controls,

--- a/simulator/data_simulator.py
+++ b/simulator/data_simulator.py
@@ -1,5 +1,4 @@
 import asyncio
-import json
 import logging
 import os
 import time
@@ -55,7 +54,7 @@ async def stream():
     feature_vector_list = get_feature_vectors(num_messages)
 
     # Construct the WebSocket URI (e.g., ws://localhost:8765)
-    uri = f"ws://{WEBSOCKET_URL}:{WEBSOCKET_PORT}"
+    uri = "ws://0.0.0.0:8765/lse"
     logger.info(f"Connecting to {uri}...")
 
     # Connect to the server
@@ -64,7 +63,7 @@ async def stream():
 
     for index, latent_vector in zip(range(num_messages), feature_vector_list):
         message = {
-            "tiled_uri": DATA_TILED_URI,
+            "tiled_url": DATA_TILED_URI,
             "index": index,
             "feature_vector": latent_vector.tolist(),
         }
@@ -73,7 +72,6 @@ async def stream():
         # Send the message (as JSON) to the server
         yield message
 
-        await asyncio.sleep(1)
+        await asyncio.sleep(0.05)
 
     logger.info("All messages sent; connection closed.")
-

--- a/src/assets/clientside.js
+++ b/src/assets/clientside.js
@@ -1,0 +1,117 @@
+window.dash_clientside = Object.assign({}, window.dash_clientside, {
+    liveWS: {
+        updateLiveData: function(message, buffer_data, n_clicks, data_project_dict, live_indices) {
+            if (n_clicks !== null && n_clicks % 2 === 1) {
+                try {
+                    console.log("Clientside callback triggered with message:", message);
+                    console.log("Current buffer_data:", buffer_data, "Type:", typeof buffer_data);
+
+                    if (!Array.isArray(buffer_data)) buffer_data = [];
+                    if (!data_project_dict || typeof data_project_dict !== 'object') {
+                        data_project_dict = {
+                            "root_uri": "",
+                            "data_type": "",
+                            "datasets": []
+                        };
+                    }
+                    if (!Array.isArray(live_indices)) live_indices = [];
+
+                    if (message && message.data) {
+                        let data = message.data;
+                        console.log("Raw message data:", data);
+
+                        if (typeof data === "string") {
+                            try {
+                                data = JSON.parse(data);
+                                console.log("Parsed message data:", data);
+                            } catch (e) {
+                                console.error("Failed to parse message data:", e);
+                                return [buffer_data, data_project_dict, live_indices];
+                            }
+                        }
+
+                        let new_entry = {};
+                        if (data.feature_vector) {
+                            console.log("Feature vector found:", data.feature_vector);
+                            new_entry["feature_vector"] = data.feature_vector;
+                            new_entry["num_components"] = data.feature_vector.length;
+                        } else {
+                            console.log("No feature vector in data.");
+                        }
+
+                        buffer_data = [...buffer_data, new_entry];
+                        console.log("Updated buffer_data:", buffer_data);
+
+                        let tiled_uri = data.tiled_uri;
+                        let index = parseInt(data.index);
+                        console.log("Tiled URI:", tiled_uri, "Index:", index);
+
+                        let url = new URL(tiled_uri);
+                        let path_parts = url.pathname.split('/');
+                        let root_uri = tiled_uri;
+                        let uri = "";
+
+                        if (path_parts.length > 1 && path_parts[path_parts.length - 1] !== '') {
+                            let root_path = path_parts.slice(0, -1).join('/') + '/';
+                            root_uri = url.protocol + '//' + url.host + root_path;
+                            uri = path_parts[path_parts.length - 1];
+                        }
+
+                        console.log("Root URI:", root_uri, "URI:", uri);
+
+                        if (index >= 0) {
+                            live_indices = [...live_indices, index];
+                            console.log("Updated live_indices:", live_indices);
+                        }
+
+                        let cum_size = Math.max(...live_indices) + 1;
+                        console.log("Cumulative size:", cum_size);
+
+                        if (data_project_dict["root_uri"] !== root_uri) {
+                            data_project_dict = {
+                                ...data_project_dict,
+                                "root_uri": root_uri,
+                                "data_type": "tiled"
+                            };
+                            console.log("Updated data_project_dict root_uri and data_type:", data_project_dict);
+                        }
+
+                        if (data_project_dict["datasets"].length === 0) {
+                            data_project_dict = {
+                                ...data_project_dict,
+                                "datasets": [{
+                                    "uri": uri,
+                                    "cumulative_data_count": cum_size
+                                }]
+                            };
+                            console.log("Initialized datasets in data_project_dict:", data_project_dict["datasets"]);
+                        } else {
+                            data_project_dict = {
+                                ...data_project_dict,
+                                "datasets": [
+                                    ...data_project_dict["datasets"],
+                                    {
+                                        "uri": uri,
+                                        "cumulative_data_count": cum_size
+                                    }
+                                ]
+                            };
+                            console.log("Appended to datasets in data_project_dict:", data_project_dict["datasets"]);
+                        }
+                    }
+
+                    return [buffer_data, data_project_dict, live_indices];
+
+                } catch (error) {
+                    console.error("Error in clientside callback:", error);
+                    return [
+                        Array.isArray(buffer_data) ? buffer_data : [],
+                        data_project_dict || { "root_uri": "", "data_type": "", "datasets": [] },
+                        Array.isArray(live_indices) ? live_indices : []
+                    ];
+                }
+            }
+            return [buffer_data, data_project_dict, live_indices];
+        }
+    }
+});

--- a/src/assets/clientside.js
+++ b/src/assets/clientside.js
@@ -7,12 +7,14 @@ window.dash_clientside = Object.assign({}, window.dash_clientside, {
                     console.log("Current buffer_data:", buffer_data, "Type:", typeof buffer_data);
 
                     if (!Array.isArray(buffer_data)) buffer_data = [];
-                    if (!data_project_dict || typeof data_project_dict !== 'object') {
+                    if (data_project_dict = {}) {
                         data_project_dict = {
                             "root_uri": "",
                             "data_type": "",
-                            "datasets": []
+                            "datasets": [],
+                            "project_id": "live",
                         };
+                        console.log("Initialized data_project_dict:", data_project_dict);
                     }
                     if (!Array.isArray(live_indices)) live_indices = [];
 
@@ -42,13 +44,13 @@ window.dash_clientside = Object.assign({}, window.dash_clientside, {
                         buffer_data = [...buffer_data, new_entry];
                         console.log("Updated buffer_data:", buffer_data);
 
-                        let tiled_uri = data.tiled_uri;
+                        let tiled_url = data.tiled_url;
                         let index = parseInt(data.index);
-                        console.log("Tiled URI:", tiled_uri, "Index:", index);
+                        console.log("Tiled URI:", tiled_url, "Index:", index);
 
-                        let url = new URL(tiled_uri);
+                        let url = new URL(tiled_url);
                         let path_parts = url.pathname.split('/');
-                        let root_uri = tiled_uri;
+                        let root_uri = tiled_url;
                         let uri = "";
 
                         if (path_parts.length > 1 && path_parts[path_parts.length - 1] !== '') {

--- a/src/components/main_display.py
+++ b/src/components/main_display.py
@@ -15,6 +15,7 @@ NUM_IMGS_OVERVIEW = 6
 WEBSOCKET_URL = os.getenv("WEBSOCKET_URL", "ws://localhost:8765/lse")
 logger.info(f"WebSocket URL: {WEBSOCKET_URL}")
 
+
 def main_display():
     main_display = html.Div(
         id="main-display",
@@ -214,6 +215,7 @@ def main_display():
             ),
             dcc.Store(id="buffer", data={}),
             dcc.Store(id="live-indices", data=[]),
+            dcc.Interval(id="buffer-debounce", interval=100, n_intervals=0),  # 100ms
             WebSocket(id="ws-live", url=WEBSOCKET_URL),
         ],
     )


### PR DESCRIPTION
This PR moves buffer, data project and indices clientside and addresses [issue #36](https://github.com/mlexchange/mlex_latent_explorer/issues/36). On the server side, the feature vector plot is updated every 100 ms. Further investigation is needed to optimize the plot update approach to better keep pace with the input data rate.

Still missing a unit test (considering implementing this in JavaScript) to be added in a later PR.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210622152628373