### PR TITLE
add vae wrapper

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,14 +69,25 @@ NUMBA_DISABLE_JIT=1
 NUMBA_CPU_NAME=generic
 NUMBA_CPU_FEATURES=+neon
 
-#Log model to mlflow
+#-----Log wrapped ML models to mlflow------
 MLFLOW_TRACKING_URI_OUTSIDE=http://localhost:5000
-#mlflow logging setting
-MLFLOW_EXPERIMENT_NAME="smi_exp"
-MLFLOW_AUTO_MODEL_NAME="smi_auto_vit"
-MLFLOW_DR_MODEL_NAME="smi_dr_umap"
-#source files
-AUTOENCODER_WEIGHTS_PATH="../models/vit/vit_model_weights.npz"
-AUTOENCODER_CODE_PATH="../models/vit/vit.py"
-DR_WEIGHTS_PATH="../models/vit/vit_joblib_test.joblib"
-LATENT_DIM=64
+#Autoencoder type: VIT or VAE
+AUTOENCODER_TYPE="VIT"
+# Used when AUTOENCODER_TYPE=VIT
+VIT_WEIGHTS_PATH="../models/vit/vit_model_weights.npz"
+VIT_CODE_PATH="../models/vit/vit.py"
+VIT_DR_WEIGHTS_PATH="../models/vit/vit_joblib_test.joblib"
+VIT_LATENT_DIM=64
+VIT_IMAGE_SIZE=(512, 512)
+VIT_MLFLOW_EXPERIMENT_NAME="smi_exp_vit"
+VIT_MLFLOW_AUTO_MODEL_NAME="smi_auto_vit"
+VIT_MLFLOW_DR_MODEL_NAME="smi_dr_umap_vit"
+# Used when AUTOENCODER_TYPE=VAE
+VAE_WEIGHTS_PATH="../models/vae/vae_model_512_weights.npz"
+VAE_CODE_PATH="../models/vae/vae.py"
+VAE_DR_WEIGHTS_PATH="../models/vae/vae_joblib_test.joblib"
+VAE_LATENT_DIM=512
+VAE_IMAGE_SIZE=(512, 512)
+VAE_MLFLOW_EXPERIMENT_NAME="smi_exp_vae"
+VAE_MLFLOW_AUTO_MODEL_NAME="smi_auto_vae"
+VAE_MLFLOW_DR_MODEL_NAME="smi_dr_umap_vae"

--- a/.env.example
+++ b/.env.example
@@ -69,25 +69,5 @@ NUMBA_DISABLE_JIT=1
 NUMBA_CPU_NAME=generic
 NUMBA_CPU_FEATURES=+neon
 
-#-----Log wrapped ML models to mlflow------
+#MLflow URI for logging wrapped ML models
 MLFLOW_TRACKING_URI_OUTSIDE=http://localhost:5000
-#Autoencoder type: VIT or VAE
-AUTOENCODER_TYPE="VIT"
-# Used when AUTOENCODER_TYPE=VIT
-VIT_WEIGHTS_PATH="../models/vit/vit_model_weights.npz"
-VIT_CODE_PATH="../models/vit/vit.py"
-VIT_DR_WEIGHTS_PATH="../models/vit/vit_joblib_test.joblib"
-VIT_LATENT_DIM=64
-VIT_IMAGE_SIZE=(512, 512)
-VIT_MLFLOW_EXPERIMENT_NAME="smi_exp_vit"
-VIT_MLFLOW_AUTO_MODEL_NAME="smi_auto_vit"
-VIT_MLFLOW_DR_MODEL_NAME="smi_dr_umap_vit"
-# Used when AUTOENCODER_TYPE=VAE
-VAE_WEIGHTS_PATH="../models/vae/vae_model_512_weights.npz"
-VAE_CODE_PATH="../models/vae/vae.py"
-VAE_DR_WEIGHTS_PATH="../models/vae/vae_joblib_test.joblib"
-VAE_LATENT_DIM=512
-VAE_IMAGE_SIZE=(512, 512)
-VAE_MLFLOW_EXPERIMENT_NAME="smi_exp_vae"
-VAE_MLFLOW_AUTO_MODEL_NAME="smi_auto_vae"
-VAE_MLFLOW_DR_MODEL_NAME="smi_dr_umap_vae"

--- a/README.md
+++ b/README.md
@@ -90,20 +90,38 @@ docker compose down
 
 This will **shut down all services** but **retain data** if volumes are used.
 
-### 8. Test Live Mode
+### 8. Test Live Mode Processing wth Arroyo
 
-1. Download model checkpoints from Google Drive.
+`arroyopy` and `arroyosas` code has been added to create a pipeline that does dimensionality reduction in a streaming fashion, providing faster reduction on models that are loaded at startup, avoidng latency from Prefect. Follow the instructions below to test the live mode:
 
-2. Configure environment variables in `.env`:
+1. Download model checkpoints from Google Drive. We recommend you put the files using the following structure
+```
+models
+├── vit
+│   ├── vit.py
+│   ├── vit_model_weights.npz
+│   └── vit_joblib_test.joblib
+├── vae
+│   ├── vae.py
+│   ├── vae_model_512_weights.npz
+│   └── vae_joblib_test.joblib
 
 ```
-MLFLOW_EXPERIMENT_NAME="smi_experiment"
-MLFLOW_VIT_MODEL_NAME="smi_auto_vit"
-MLFLOW_UMAP_MODEL_NAME="smi_dr_umap"
-AUTOENCODER_WEIGHTS_PATH="./models/vit/vit_model_weights.npz"
-AUTOENCODER_CODE_PATH="./models/vit/vit.py"
-UMAP_WEIGHTS_PATH="./models/vit/vit_joblib_test.joblib"
-LATENT_DIM=64
+
+2. Configure environment variables in `.env`:
+Set the model type by modifying the following variable to either "VIT" or "VAE", depending on which model you want to log to the MLflow server:
+```
+AUTOENCODER_TYPE="VIT"
+```
+
+Also, make sure the following paths are correctly set in `.env`. If you use the recommended directory structure, these defaults will work:
+```
+VIT_WEIGHTS_PATH="../models/vit/vit_model_weights.npz"
+VIT_CODE_PATH="../models/vit/vit.py"
+VIT_DR_WEIGHTS_PATH="../models/vit/vit_joblib_test.joblib"
+VAE_WEIGHTS_PATH="../models/vae/vae_model_512_weights.npz"
+VAE_CODE_PATH="../models/vae/vae.py"
+VAE_DR_WEIGHTS_PATH="../models/vae/vae_joblib_test.joblib"
 ```
 
 3. Start the services:
@@ -161,55 +179,6 @@ pre-commit run --all-files
 python -m pytest
 ```
 
-## Live Mode Processing wth Arroyo
-arroyopy and arroyosas code has been added to create a pipeline that does dimensionality reduction in a streaming fashion, providing faster reduction on models that are loaded at startup, avoidng latency from Prefect.
-
-### Setup
-Copy a provided "models" directory into the root of the project.
-
-Note that this step will go away when MLFlow is integrated.
-
-The following file structure is
-```
-models
-├── cnn_autoencoder
-│   ├── model.py
-│   └── model_state_dict.npz
-├── g_saxs
-│   ├── ViT.py
-│   ├── model_weights.npz
-│   └── vit_joblib.joblib
-└── t_waxs
-    ├── ViT.py
-    ├── __pycache__
-    │   └── ViT.cpython-311.pyc
-    ├── model_weights.npz
-    └── vit_joblib_test.joblib
-```
-
-maps to the `lse_reducer` section in arroyo_settings.yml:
-```
-lse_reducer:
-  models:
-    - name: CNNAutoencoder
-      state_dict: ./models/cnn_autoencoder/model_state_dict.npz
-      python_class: CNNAutoencoder
-      python_file: ./models/cnn_autoencoder/model.py
-      type: torch
-    
-    - name: AE
-      state_dict: ./models/ae_v1/ae_model_finetuned.npz
-      python_class: CNNAutoencoder
-      python_file: ./models/ae_v1/ae.py
-      type: torch
-
-    - name: UMAP
-      file: ./models/umap/quick_test.joblib
-      type: joblib
-      
-  current_latent_space: AE
-  current_dim_reduction: UMAP
-```
 
 ## Copyright
 MLExchange Copyright (c) 2023, The Regents of the University of California,

--- a/README.md
+++ b/README.md
@@ -108,21 +108,14 @@ models
 
 ```
 
-2. Configure environment variables in `.env`:
+2. Configure variables in `live_operator_example/mlflow_config.yaml`:
 Set the model type by modifying the following variable to either "VIT" or "VAE", depending on which model you want to log to the MLflow server:
 ```
-AUTOENCODER_TYPE="VIT"
+common:
+  autoencoder_type: "VIT"  # use VIT or VAE
 ```
 
-Also, make sure the following paths are correctly set in `.env`. If you use the recommended directory structure, these defaults will work:
-```
-VIT_WEIGHTS_PATH="../models/vit/vit_model_weights.npz"
-VIT_CODE_PATH="../models/vit/vit.py"
-VIT_DR_WEIGHTS_PATH="../models/vit/vit_joblib_test.joblib"
-VAE_WEIGHTS_PATH="../models/vae/vae_model_512_weights.npz"
-VAE_CODE_PATH="../models/vae/vae.py"
-VAE_DR_WEIGHTS_PATH="../models/vae/vae_joblib_test.joblib"
-```
+Also, make sure the file paths are correctly set in `mlflow_config.yaml`. If you use the recommended directory structure, the defaults will work.
 
 3. Start the services:
 ```

--- a/live_operator_example/lse_operator.py
+++ b/live_operator_example/lse_operator.py
@@ -1,13 +1,15 @@
+import logging
 import os
 import sys
-import logging
+
 import numpy as np
 import torch
-from tiled.client import from_uri
-from tiled_utils import write_results
 
 # Import the MLflowClient class
 from src.utils.mlflow_utils import MLflowClient
+from tiled.client import from_uri
+
+from tiled_utils import write_results
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
@@ -26,8 +28,10 @@ MLFLOW_TRACKING_PASSWORD = os.getenv("MLFLOW_TRACKING_PASSWORD", "")
 
 # Add compatibility patch for torch if needed
 if not hasattr(torch, "get_default_device"):
+
     def get_default_device():
         return torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
     torch.get_default_device = get_default_device
 
 if __name__ == "__main__":
@@ -35,26 +39,28 @@ if __name__ == "__main__":
     mlflow_client = MLflowClient(
         tracking_uri=MLFLOW_TRACKING_URI,
         username=MLFLOW_TRACKING_USERNAME,
-        password=MLFLOW_TRACKING_PASSWORD
+        password=MLFLOW_TRACKING_PASSWORD,
     )
-    
+
     # Check if MLflow is reachable
     if not mlflow_client.check_mlflow_ready():
         logger.error("MLflow server is not reachable. Exiting.")
         sys.exit(1)
-    
+
     # Get model names from environment variables or command line arguments
-    autoencoder_model_name = os.getenv("MLFLOW_AUTO_MODEL_NAME", "smi_autoencoder_model_wrapper")
+    autoencoder_model_name = os.getenv(
+        "MLFLOW_AUTO_MODEL_NAME", "smi_autoencoder_model_wrapper"
+    )
     dimred_model_name = os.getenv("MLFLOW_DR_MODEL_NAME", "smi_umap_model_wrapper")
-    
+
     # Load the autoencoder model with wrapper
     logger.info(f"Loading autoencoder model: {autoencoder_model_name}")
     autoencoder_wrapper = mlflow_client.load_model(autoencoder_model_name)
-    
+
     if autoencoder_wrapper is None:
         logger.error("Failed to load autoencoder model. Exiting.")
         sys.exit(1)
-    
+
     # Load the dimension reduction model with wrapper
     logger.info(f"Loading dimension reduction model from MLflow: {dimred_model_name}")
     dimred_wrapper = mlflow_client.load_model(dimred_model_name)
@@ -62,9 +68,9 @@ if __name__ == "__main__":
     if dimred_wrapper is None:
         logger.error("Failed to load dimension reduction model. Exiting.")
         sys.exit(1)
-    
+
     # The PyFunc wrappers handle device management internally
-    
+
     # No need for custom transforms as the PyFunc wrapper handles preprocessing
 
     # Set up Tiled clients
@@ -77,24 +83,26 @@ if __name__ == "__main__":
         try:
             # Get datapoint from Tiled
             datapoint = data_client[indx]  # noqa: F821
-            
+
             # datapoint is a numpy array (the wrapper expects numpy input)
             img_array = datapoint
-            
+
             # Log information about the image
-            logger.info(f"Processing image {i}: shape={img_array.shape}, dtype={img_array.dtype}")
-            
+            logger.info(
+                f"Processing image {i}: shape={img_array.shape}, dtype={img_array.dtype}"
+            )
+
             # Process with autoencoder to get latent features
             # Pass the numpy array directly to the model wrapper
             autoencoder_result = autoencoder_wrapper.predict(img_array)
             latent_features = autoencoder_result["latent_features"]
             logger.info(f"Extracted latent features: shape={latent_features.shape}")
-            
+
             # Apply dimension reduction using the UMAP wrapper
             umap_result = dimred_wrapper.predict(latent_features)
             f_vec = umap_result["umap_coords"]
             logger.info(f"UMAP coordinates: shape={f_vec.shape}")
-            
+
             # Save results to Tiled
             write_results(
                 write_client,
@@ -103,10 +111,11 @@ if __name__ == "__main__":
                 latent_vectors_path,  # noqa: F821
                 metadata=None,
             )
-            
+
             logger.info(f"Processed datapoint {i} successfully")
-            
+
         except Exception as e:
             logger.error(f"Error processing datapoint {i}: {e}")
             import traceback
+
             traceback.print_exc()

--- a/live_operator_example/mlflow_config.yaml
+++ b/live_operator_example/mlflow_config.yaml
@@ -1,0 +1,25 @@
+# Common settings
+common:
+  autoencoder_type: "VIT"  # use VIT or VAE
+
+# Model configurations
+models:
+  vit:
+    experiment_name: "smi_exp_vit"
+    auto_model_name: "smi_auto_vit"
+    dr_model_name: "smi_dr_umap_vit"
+    weights_path: "../models/vit/vit_model_weights.npz"
+    code_path: "../models/vit/vit.py"
+    dr_weights_path: "../models/vit/vit_joblib_test.joblib"
+    latent_dim: 64
+    image_size: [512, 512]
+  
+  vae:
+    experiment_name: "smi_exp_vae"
+    auto_model_name: "smi_auto_vae"
+    dr_model_name: "smi_dr_umap_vae"
+    weights_path: "../models/vae/vae_model_512_weights.npz"
+    code_path: "../models/vae/vae.py"
+    dr_weights_path: "../models/vae/vae_joblib_test.joblib"
+    latent_dim: 512
+    image_size: [512, 512]

--- a/live_operator_example/save_mlflow_wrapper.py
+++ b/live_operator_example/save_mlflow_wrapper.py
@@ -2,9 +2,12 @@
 """
 MLflow Model Saving Utility
 
-This script saves autoencoder and dimensionality reduction models to MLflow:
-- Autoencoder model: Using PyFunc wrapper with get_latent_features functionality
+This script saves either a ViT autoencoder or VAE model to MLflow, along with their
+corresponding dimensionality reduction model:
+- Autoencoder/VAE model: Using PyFunc wrapper with get_latent_features functionality
 - Dimensionality reduction model: Using PyFunc wrapper
+
+The model type (VIT or VAE) is determined by the AUTOENCODER_TYPE environment variable.
 """
 
 import os
@@ -14,62 +17,92 @@ import traceback
 # Fix transformers compatibility BEFORE any imports
 os.environ["TRANSFORMERS_USE_TORCH_EXPORT"] = "0"
 
-from dotenv import load_dotenv
 import mlflow
-
-# Import wrappers and saving functions
-from vit_wrapper import save_vit_model_with_wrapper
-from umap_wrapper import save_umap_model_with_wrapper
+from dotenv import load_dotenv
 
 # Load environment variables from .env file
-load_dotenv(dotenv_path='../.env') 
+load_dotenv(dotenv_path="../.env")
+
+# Determine which model wrappers to import based on autoencoder type
+AUTOENCODER_TYPE = os.getenv("AUTOENCODER_TYPE", "VIT").upper()
+if AUTOENCODER_TYPE == "VIT":
+    from vit_wrapper import save_vit_model_with_wrapper as save_model_fn
+elif AUTOENCODER_TYPE == "VAE":
+    from vae_wrapper import save_vae_model_with_wrapper as save_model_fn
+else:
+    print(f"⚠️ Invalid AUTOENCODER_TYPE: {AUTOENCODER_TYPE}. Must be 'VIT' or 'VAE'.")
+    sys.exit(1)
+
+# Always import UMAP wrapper
+from umap_wrapper import save_umap_model_with_wrapper
 
 # MLflow Configuration from environment variables
 MLFLOW_TRACKING_URI = os.getenv("MLFLOW_TRACKING_URI_OUTSIDE", "http://localhost:5000")
 MLFLOW_TRACKING_USERNAME = os.getenv("MLFLOW_TRACKING_USERNAME", "")
 MLFLOW_TRACKING_PASSWORD = os.getenv("MLFLOW_TRACKING_PASSWORD", "")
-# Names for logging experiment and model
-MLFLOW_EXPERIMENT_NAME = os.getenv("MLFLOW_EXPERIMENT_NAME", "smi_exp")
-MLFLOW_AUTO_MODEL_NAME = os.getenv("MLFLOW_AUTO_MODEL_NAME", "smi_auto")
-MLFLOW_DR_MODEL_NAME = os.getenv("MLFLOW_DR_MODEL_NAME", "smi_dr")
-
-# Load source files
-AUTOENCODER_WEIGHTS_PATH= os.getenv("AUTOENCODER_WEIGHTS_PATH")
-AUTOENCODER_CODE_PATH= os.getenv("AUTOENCODER_CODE_PATH")
-DR_WEIGHTS_PATH= os.getenv("DR_WEIGHTS_PATH")
-LATENT_DIM= os.getenv("LATENT_DIM")
 
 # Set MLflow authentication
 os.environ["MLFLOW_TRACKING_USERNAME"] = MLFLOW_TRACKING_USERNAME
 os.environ["MLFLOW_TRACKING_PASSWORD"] = MLFLOW_TRACKING_PASSWORD
 
+# Load model-specific configuration based on autoencoder type
+if AUTOENCODER_TYPE == "VIT":
+    # For ViT model, use VIT-specific variables
+    AUTOENCODER_WEIGHTS_PATH = os.getenv("VIT_WEIGHTS_PATH")
+    AUTOENCODER_CODE_PATH = os.getenv("VIT_CODE_PATH")
+    DR_WEIGHTS_PATH = os.getenv("VIT_DR_WEIGHTS_PATH")
+    LATENT_DIM = os.getenv("VIT_LATENT_DIM")
+    IMAGE_SIZE_STR = os.getenv("VIT_IMAGE_SIZE", "(512, 512)")
+    MLFLOW_EXPERIMENT_NAME = os.getenv("VIT_MLFLOW_EXPERIMENT_NAME")
+    MLFLOW_AUTO_MODEL_NAME = os.getenv("VIT_MLFLOW_AUTO_MODEL_NAME")
+    MLFLOW_DR_MODEL_NAME = os.getenv("VIT_MLFLOW_DR_MODEL_NAME")
+else:  # AUTOENCODER_TYPE == "VAE"
+    # For VAE model, use VAE-specific variables
+    AUTOENCODER_WEIGHTS_PATH = os.getenv("VAE_WEIGHTS_PATH")
+    AUTOENCODER_CODE_PATH = os.getenv("VAE_CODE_PATH")
+    DR_WEIGHTS_PATH = os.getenv("VAE_DR_WEIGHTS_PATH")
+    LATENT_DIM = os.getenv("VAE_LATENT_DIM")
+    IMAGE_SIZE_STR = os.getenv("VAE_IMAGE_SIZE", "(512, 512)")
+    MLFLOW_EXPERIMENT_NAME = os.getenv("VAE_MLFLOW_EXPERIMENT_NAME")
+    MLFLOW_AUTO_MODEL_NAME = os.getenv("VAE_MLFLOW_AUTO_MODEL_NAME")
+    MLFLOW_DR_MODEL_NAME = os.getenv("VAE_MLFLOW_DR_MODEL_NAME")
+
+# Parse IMAGE_SIZE for both models
+try:
+    # Convert string to tuple
+    IMAGE_SIZE = eval(IMAGE_SIZE_STR)
+except Exception as e:
+    print(f"⚠️ Error parsing IMAGE_SIZE: {e}. Using default (512, 512).")
+    IMAGE_SIZE = (512, 512)
+
+
 # Print configuration for verification
 print("----------------------------------------------")
-print("MLFLOW_TRACKING_URI:",MLFLOW_TRACKING_URI)
-print("MLFLOW_EXPERIMENT_NAME:",MLFLOW_EXPERIMENT_NAME)
-print("MLFLOW_AUTO_MODEL_NAME:",MLFLOW_AUTO_MODEL_NAME)
-print("MLFLOW_DR_MODEL_NAME:",MLFLOW_DR_MODEL_NAME)
-print("AUTOENCODER_WEIGHTS_PATH:",AUTOENCODER_WEIGHTS_PATH)
-print("AUTOENCODER_CODE_PATH:",AUTOENCODER_CODE_PATH)
-print("DR_WEIGHTS_PATH:",DR_WEIGHTS_PATH)
-print("LATENT_DIM:",LATENT_DIM)
+print("MLFLOW_TRACKING_URI:", MLFLOW_TRACKING_URI)
+print("AUTOENCODER_TYPE:", AUTOENCODER_TYPE)
+print("MLFLOW_EXPERIMENT_NAME:", MLFLOW_EXPERIMENT_NAME)
+print("MLFLOW_AUTO_MODEL_NAME:", MLFLOW_AUTO_MODEL_NAME)
+print("MLFLOW_DR_MODEL_NAME:", MLFLOW_DR_MODEL_NAME)
+print("AUTOENCODER_WEIGHTS_PATH:", AUTOENCODER_WEIGHTS_PATH)
+print("AUTOENCODER_CODE_PATH:", AUTOENCODER_CODE_PATH)
+print("DR_WEIGHTS_PATH:", DR_WEIGHTS_PATH)
+print("LATENT_DIM:", LATENT_DIM)
+print("IMAGE_SIZE:", IMAGE_SIZE)
 print("----------------------------------------------")
 
-# Model configurations
+# Configure model with a single configuration structure for both types
 MODEL_CONFIG = {
     "name": "SMI_Autoencoder",
     "state_dict": AUTOENCODER_WEIGHTS_PATH,
     "python_class": "Autoencoder",
     "python_file": AUTOENCODER_CODE_PATH,
     "type": "torch",
-    "latent_dim": LATENT_DIM
+    "latent_dim": LATENT_DIM,
+    "image_size": IMAGE_SIZE,
 }
 
-JOBLIB_CONFIG = {
-    "name": "SMI_DimRed",
-    "file": DR_WEIGHTS_PATH,
-    "type": "joblib"
-}
+# UMAP configuration with consistent name
+JOBLIB_CONFIG = {"name": "SMI_DimRed", "file": DR_WEIGHTS_PATH, "type": "joblib", "input_dim": LATENT_DIM}
 
 if __name__ == "__main__":
     try:
@@ -81,39 +114,52 @@ if __name__ == "__main__":
         except Exception as e:
             print(f"⚠️  Cannot connect to MLflow server at {MLFLOW_TRACKING_URI}: {e}")
             sys.exit(1)
-        
-        print(f"\nSaving both models with names:")
-        print(f"  Autoencoder model: {MLFLOW_AUTO_MODEL_NAME}")
+
+        print(f"\nSaving models with names:")
+        print(f"  {AUTOENCODER_TYPE} model: {MLFLOW_AUTO_MODEL_NAME}")
         print(f"  Dimensionality reduction model: {MLFLOW_DR_MODEL_NAME}")
-        
-        # Save autoencoder model with PyFunc wrapper
-        auto_name, auto_run_id = save_vit_model_with_wrapper(
-            MODEL_CONFIG, 
-            MLFLOW_TRACKING_URI,
-            MLFLOW_EXPERIMENT_NAME,
-            MLFLOW_AUTO_MODEL_NAME
-        )
-        
+
+        # Initialize success trackers
+        auto_success = False
+        dr_success = False
+
+        # Save model with PyFunc wrapper
+        if AUTOENCODER_WEIGHTS_PATH and AUTOENCODER_CODE_PATH:
+            auto_name, auto_run_id = save_model_fn(
+                MODEL_CONFIG,
+                MLFLOW_TRACKING_URI,
+                MLFLOW_EXPERIMENT_NAME,
+                MLFLOW_AUTO_MODEL_NAME,
+            )
+            auto_success = bool(auto_name)
+        else:
+            print(f"\n⚠️ Skipping {AUTOENCODER_TYPE} model: missing configuration")
+
         # Save dimensionality reduction model with wrapper
-        dr_name, dr_run_id = save_umap_model_with_wrapper(
-            JOBLIB_CONFIG,
-            MLFLOW_TRACKING_URI,
-            MLFLOW_EXPERIMENT_NAME, 
-            MLFLOW_DR_MODEL_NAME
-        )
-        
+        if DR_WEIGHTS_PATH:
+            dr_name, dr_run_id = save_umap_model_with_wrapper(
+                JOBLIB_CONFIG,
+                MLFLOW_TRACKING_URI,
+                MLFLOW_EXPERIMENT_NAME,
+                MLFLOW_DR_MODEL_NAME,
+            )
+            dr_success = bool(dr_name)
+        else:
+            print("\n⚠️ Skipping dimensionality reduction model: missing configuration")
+
         # Report results
-        if auto_name and dr_name:
+        print("\n---------- SUMMARY ----------")
+        if auto_success and dr_success:
             print(f"\n✅ Both models saved successfully!")
-        elif auto_name:
-            print(f"\n✅ Autoencoder model saved successfully!")
+        elif auto_success:
+            print(f"\n✅ {AUTOENCODER_TYPE} model saved successfully!")
             print(f"⚠️ Dimensionality reduction model failed to save.")
-        elif dr_name:
+        elif dr_success:
             print(f"\n✅ Dimensionality reduction model saved successfully!")
-            print(f"⚠️ Autoencoder model failed to save.")
+            print(f"⚠️ {AUTOENCODER_TYPE} model failed to save.")
         else:
             print(f"\n⚠️ Failed to save both models.")
-        
+
     except Exception as e:
         print(f"\nError: {e}")
         traceback.print_exc()

--- a/live_operator_example/umap_wrapper.py
+++ b/live_operator_example/umap_wrapper.py
@@ -9,9 +9,9 @@ import time
 import traceback
 from datetime import datetime
 
-import numpy as np
 import joblib
 import mlflow
+import numpy as np
 
 
 def get_file_size_mb(filepath):
@@ -23,117 +23,129 @@ def get_file_size_mb(filepath):
 
 class UMAPModelWrapper(mlflow.pyfunc.PythonModel):
     """Wrapper for UMAP model with direct model access"""
-    
+
     def __init__(self):
         self.model = None
-    
+
     def load_context(self, context):
         """Load UMAP model from context artifacts"""
         # Load UMAP model
         umap_path = context.artifacts.get("umap_model")
         if not umap_path or not os.path.exists(umap_path):
             raise FileNotFoundError(f"UMAP model not found in artifacts")
-        
+
         print(f"Loading UMAP model from {umap_path}")
         self.model = joblib.load(umap_path)
         print("✓ UMAP model loaded successfully")
-    
+
     def predict(self, context, model_input):
         """
         Standard predict method for UMAP model
-        
+
         Args:
             context: MLflow context
             model_input: Input data as numpy array
-            
+
         Returns:
             Dictionary with UMAP coordinates
         """
         if self.model is None:
             raise RuntimeError("UMAP model not loaded. Call load_context first.")
-        
+
         # Validate input
         if not isinstance(model_input, np.ndarray):
             raise ValueError(f"Input must be a numpy array, got {type(model_input)}")
-            
+
         # Check input dimensions
         if len(model_input.shape) != 2 or model_input.shape[0] != 1:
-            raise ValueError(f"Input must be a 2D array with shape (1, latent_dim), got shape {model_input.shape}")
-        
+            raise ValueError(
+                f"Input must be a 2D array with shape (1, latent_dim), got shape {model_input.shape}"
+            )
+
         # Apply UMAP transformation
         umap_coords = self.model.transform(model_input)
-        
+
         # Return results
-        return {
-            "umap_coords": umap_coords
-        }
+        return {"umap_coords": umap_coords}
 
 
-def save_umap_model_with_wrapper(model_config, tracking_uri, experiment_name, model_name=None):
+def save_umap_model_with_wrapper(
+    model_config, tracking_uri, experiment_name, model_name=None
+):
     """
     Save dimensionality reduction model with a direct access wrapper
-    
+
     Args:
         model_config: Dictionary with model configuration
         tracking_uri: MLflow tracking URI
         experiment_name: MLflow experiment name
         model_name: Optional model name, defaults to name from config with date
-        
+
     Returns:
         Tuple of (model_name, run_id) or (None, None) on failure
     """
-    
+
     # Set MLflow tracking
     mlflow.set_tracking_uri(tracking_uri)
     mlflow.set_experiment(experiment_name)
-    
+
     # Set model name
     if model_name is None:
         model_name = f"{model_config['name']}_v{datetime.now().strftime('%Y%m%d')}"
-    
+
     print(f"\nSaving dimensionality reduction model as: {model_name}")
-    
+
     start_time = time.time()
-    
-    with mlflow.start_run(run_name=f"dr_model_{datetime.now().strftime('%Y%m%d_%H%M%S')}") as run:
+
+    with mlflow.start_run(
+        run_name=f"dr_model_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
+    ) as run:
         print(f"Run ID: {run.info.run_id}")
         print(f"MLflow tracking URI: {tracking_uri}")
-        
+
         # Check file existence
         if not os.path.exists(model_config["file"]):
-            print(f"⚠️ Dimensionality reduction model file not found at {model_config['file']}")
+            print(
+                f"⚠️ Dimensionality reduction model file not found at {model_config['file']}"
+            )
             return None, None
-            
+
         # Check file size
         joblib_size = get_file_size_mb(model_config["file"])
         print(f"\nFile size: {joblib_size:.1f} MB")
-        
+
         try:
             # Create model wrapper
             umap_wrapper = UMAPModelWrapper()
-            
+
             # Log parameters
-            mlflow.log_params({
-                "model_name": model_config["name"],
-                "model_type": model_config["type"],
-                "joblib_size_mb": joblib_size,
-                "using_wrapper": True,
-            })
-            
+            mlflow.log_params(
+                {
+                    "model_name": model_config["name"],
+                    "model_type": model_config["type"],
+                    "joblib_size_mb": joblib_size,
+                    "using_wrapper": True,
+                    "input_dim": model_config["input_dim"],
+                }
+            )
+
             # Set tags
-            mlflow.set_tags({
-                "exp_type": "live_mode",
-                "model_type": "dimension_reduction"
-            })
-            
+            mlflow.set_tags(
+                {"exp_type": "live_mode", "model_type": "dimension_reduction"}
+            )
+
             # Create artifacts dictionary
-            artifacts = {
-                "umap_model": model_config["file"]
-            }
-            
+            artifacts = {"umap_model": model_config["file"]}
+
             # Define explicit requirements
-            pip_requirements = ["numpy", "scikit-learn", "joblib", "mlflow==2.22.0", "umap-learn"]
-            
+            pip_requirements = [
+                "numpy",
+                "scikit-learn",
+                "joblib",
+                "mlflow==2.22.0",
+                "umap-learn",
+            ]
+
             # Log the dimensionality reduction model wrapper
             try:
                 print("\nLogging dimensionality reduction model wrapper to MLflow...")
@@ -143,25 +155,29 @@ def save_umap_model_with_wrapper(model_config, tracking_uri, experiment_name, mo
                     artifacts=artifacts,
                     registered_model_name=model_name,
                     pip_requirements=pip_requirements,
-                    code_path=[__file__]  # Include this file's path
+                    code_path=[__file__],  # Include this file's path
                 )
-                print(f"✓ Dimensionality reduction model wrapper registered as '{model_name}'")
+                print(
+                    f"✓ Dimensionality reduction model wrapper registered as '{model_name}'"
+                )
             except Exception as e:
                 print(f"⚠️ Error logging dimensionality reduction model wrapper: {e}")
                 traceback.print_exc()
                 return None, None
-            
+
             # Log timing
             total_time = time.time() - start_time
             mlflow.log_metric("upload_time_seconds", total_time)
-            
-            print(f"\n✅ Dimensionality reduction model saved successfully in {total_time:.1f}s!")
+
+            print(
+                f"\n✅ Dimensionality reduction model saved successfully in {total_time:.1f}s!"
+            )
             print(f"Model name: {model_name}")
             print(f"Run ID: {run.info.run_id}")
             print(f"MLflow UI: {tracking_uri}")
-            
+
             return model_name, run.info.run_id
-            
+
         except Exception as e:
             print(f"\n❌ Error saving dimensionality reduction model: {e}")
             traceback.print_exc()

--- a/live_operator_example/vae_wrapper.py
+++ b/live_operator_example/vae_wrapper.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 """
-ViT Autoencoder wrapper for MLflow.
-Provides functionality to load a ViT autoencoder model and register it with MLflow.
+VAE wrapper for MLflow.
+Provides functionality to load a VAE model and register it with MLflow.
 """
 
 import importlib.util
@@ -25,18 +25,9 @@ def get_file_size_mb(filepath):
     return os.path.getsize(filepath) / (1024 * 1024)
 
 
-# Add compatibility patch for torch if needed
-if not hasattr(torch, "get_default_device"):
-
-    def get_default_device():
-        return torch.device("cuda" if torch.cuda.is_available() else "cpu")
-
-    torch.get_default_device = get_default_device
-
-
-class VitAutoencoderWrapper(mlflow.pyfunc.PythonModel):
+class VAEModelWrapper(mlflow.pyfunc.PythonModel):
     """
-    Wrapper for ViT Autoencoder with direct model access and latent features functionality
+    Wrapper for VAE with direct model access and latent features functionality
     """
 
     def __init__(self, latent_dim=64, image_size=(512, 512)):
@@ -46,7 +37,7 @@ class VitAutoencoderWrapper(mlflow.pyfunc.PythonModel):
         self.image_size = image_size
 
     def load_context(self, context):
-        """Load ViT model from context artifacts"""
+        """Load VAE model from context artifacts"""
         # Get the model code path
         model_code_path = context.artifacts.get("model_code")
         if not model_code_path or not os.path.exists(model_code_path):
@@ -63,13 +54,14 @@ class VitAutoencoderWrapper(mlflow.pyfunc.PythonModel):
         module = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(module)
 
-        # Get latent dimension
-        latent_dim = self.latent_dim
-        print(f"Latent Dimension is: {latent_dim}")
-        print(f"Image Size is: {self.image_size}")
+        print(
+            f"Initializing VAE with latent_dim={self.latent_dim}, image_size={self.image_size}"
+        )
 
-        # Create model instance with explicit integer for latent_dim
-        self.model = module.Autoencoder(latent_dim=int(latent_dim))
+        # Create model instance directly using ConvVAE class
+        self.model = module.ConvVAE(
+            latent_dim=self.latent_dim, image_size=self.image_size
+        )
 
         # Load weights from NPZ file
         weights_path = context.artifacts.get("weights_path")
@@ -77,31 +69,20 @@ class VitAutoencoderWrapper(mlflow.pyfunc.PythonModel):
             raise FileNotFoundError(f"Weights file not found at {weights_path}")
 
         # Load weights
-        weights = np.load(weights_path, allow_pickle=True)
-
-        # Check for state_dict key
-        if "state_dict" in weights.files:
-            state_dict = weights["state_dict"].item()
-        else:
-            state_dict = {k: weights[k] for k in weights.files}
+        weights_npz = np.load(weights_path)
 
         # Convert numpy arrays to PyTorch tensors
-        torch_state_dict = {}
-        for k, v in state_dict.items():
-            if isinstance(v, np.ndarray):
-                torch_state_dict[k] = torch.from_numpy(v)
-            else:
-                torch_state_dict[k] = v
+        state_dict = {key: torch.tensor(weights_npz[key]) for key in weights_npz.files}
 
         # Load state dict
         try:
-            self.model.load_state_dict(torch_state_dict, strict=True)
-            print("✓ Model weights loaded successfully (strict)")
+            self.model.load_state_dict(state_dict, strict=True)
+            print("✓ VAE model weights loaded successfully (strict)")
         except Exception as e:
             print(f"⚠️ Strict loading failed: {e}")
             print("Attempting non-strict loading...")
 
-            result = self.model.load_state_dict(torch_state_dict, strict=False)
+            result = self.model.load_state_dict(state_dict, strict=False)
             if result.missing_keys:
                 print(f"Missing keys: {result.missing_keys[:5]}...")
             if result.unexpected_keys:
@@ -124,21 +105,19 @@ class VitAutoencoderWrapper(mlflow.pyfunc.PythonModel):
             [
                 transforms.Resize(self.image_size),
                 transforms.Grayscale(num_output_channels=1),
-                transforms.ToTensor(),  # Convert image to PyTorch tensor (0-1 range)
-                transforms.Normalize(
-                    (0.0,), (1.0,)
-                ),  # Normalize tensor to have mean 0 and std 1
+                transforms.ToTensor(),
+                transforms.Normalize((0.0,), (1.0,)),
             ]
         )
 
-        print(f"✓ ViT model loaded successfully with latent_dim={latent_dim}")
+        print(f"✓ VAE model loaded successfully")
 
     def predict(self, context, model_input):
         """
         Standard predict method (required by MLflow)
 
-        This method processes the input through the autoencoder model and returns both
-        the reconstruction and the latent features from the encoder.
+        This method processes the input through the VAE model and returns both
+        the reconstruction and the latent features.
 
         Args:
             context: MLflow context
@@ -148,7 +127,7 @@ class VitAutoencoderWrapper(mlflow.pyfunc.PythonModel):
             Dictionary with reconstruction and latent features
         """
         if self.model is None:
-            raise RuntimeError("ViT model not loaded. Call load_context first.")
+            raise RuntimeError("VAE model not loaded. Call load_context first.")
 
         # Validate input
         if not isinstance(model_input, np.ndarray):
@@ -204,10 +183,9 @@ class VitAutoencoderWrapper(mlflow.pyfunc.PythonModel):
 
         try:
             # Convert numpy array to PIL Image
-            # PIL.Image.fromarray handles both 2D and 3D arrays automatically
             pil_image = Image.fromarray(img_array)
 
-            # Apply transformations (resize, convert to tensor, normalize)
+            # Apply transformations
             tensor = self.transform(pil_image)
 
             # Add batch dimension and move to device
@@ -218,23 +196,28 @@ class VitAutoencoderWrapper(mlflow.pyfunc.PythonModel):
 
         # Process with model
         with torch.no_grad():
-            # Get reconstruction
-            reconstruction = self.model(tensor)
-            reconstruction_np = reconstruction.cpu().numpy()
+            # Forward pass through the model
+            x_reconstructed, mu, logvar = self.model(tensor)
 
-            # Get latent features directly from the encoder
-            latent, _ = self.model.encoder(tensor)
-            latent_features = latent.cpu().numpy()
+            # Convert reconstruction to numpy
+            reconstruction_np = x_reconstructed.cpu().numpy()
+
+            # Get latent features (mu is the mean vector in the latent space)
+            latent_features = mu.cpu().numpy()
 
         # Return results
-        return {"reconstruction": reconstruction_np, "latent_features": latent_features}
+        return {
+            "reconstruction": reconstruction_np,
+            "latent_features": latent_features,
+            "logvar": logvar.cpu().numpy(),  # Also return logvar for completeness
+        }
 
 
-def save_vit_model_with_wrapper(
+def save_vae_model_with_wrapper(
     model_config, tracking_uri, experiment_name, model_name=None
 ):
     """
-    Save autoencoder model using PyFunc wrapper with latent features functionality
+    Save VAE model using PyFunc wrapper with latent features functionality
 
     Args:
         model_config: Dictionary with model configuration
@@ -254,12 +237,12 @@ def save_vit_model_with_wrapper(
     if model_name is None:
         model_name = f"{model_config['name']}_v{datetime.now().strftime('%Y%m%d')}"
 
-    print(f"\nSaving autoencoder model with PyFunc wrapper as: {model_name}")
+    print(f"\nSaving VAE model with PyFunc wrapper as: {model_name}")
 
     start_time = time.time()
 
     with mlflow.start_run(
-        run_name=f"auto_model_wrapper_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
+        run_name=f"vae_model_wrapper_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
     ) as run:
         print(f"Run ID: {run.info.run_id}")
         print(f"MLflow tracking URI: {tracking_uri}")
@@ -283,10 +266,8 @@ def save_vit_model_with_wrapper(
             latent_dim = model_config.get("latent_dim", 64)
             image_size = model_config.get("image_size", (512, 512))
 
-            # Create model wrapper with latent dimension and image size
-            vit_wrapper = VitAutoencoderWrapper(
-                latent_dim=latent_dim, image_size=image_size
-            )
+            # Create model wrapper
+            vae_wrapper = VAEModelWrapper(latent_dim=latent_dim, image_size=image_size)
 
             # Log model information
             mlflow.log_params(
@@ -304,7 +285,7 @@ def save_vit_model_with_wrapper(
             # Set tags
             mlflow.set_tags({"exp_type": "live_mode", "model_type": "autoencoder"})
 
-            # Create artifacts dictionary - only include files
+            # Create artifacts dictionary
             artifacts = {
                 "weights_path": model_config["state_dict"],
                 "model_code": model_config["python_file"],
@@ -319,11 +300,11 @@ def save_vit_model_with_wrapper(
                 "torchvision",
             ]
 
-            # Log the autoencoder model with PyFunc wrapper
-            print("\nLogging autoencoder model with PyFunc wrapper to MLflow...")
+            # Log the VAE model with PyFunc wrapper
+            print("\nLogging VAE model with PyFunc wrapper to MLflow...")
             mlflow.pyfunc.log_model(
                 artifact_path="model",
-                python_model=vit_wrapper,
+                python_model=vae_wrapper,
                 artifacts=artifacts,
                 registered_model_name=model_name,
                 pip_requirements=pip_requirements,
@@ -334,9 +315,7 @@ def save_vit_model_with_wrapper(
             total_time = time.time() - start_time
             mlflow.log_metric("upload_time_seconds", total_time)
 
-            print(
-                f"\n✅ Autoencoder model saved with PyFunc wrapper in {total_time:.1f}s!"
-            )
+            print(f"\n✅ VAE model saved with PyFunc wrapper in {total_time:.1f}s!")
             print(f"Model name: {model_name}")
             print(f"Run ID: {run.info.run_id}")
             print(f"MLflow UI: {tracking_uri}")
@@ -344,6 +323,6 @@ def save_vit_model_with_wrapper(
             return model_name, run.info.run_id
 
         except Exception as e:
-            print(f"\n❌ Error saving autoencoder model with wrapper: {e}")
+            print(f"\n❌ Error saving VAE model with wrapper: {e}")
             traceback.print_exc()
             return None, None

--- a/src/arroyo_reduction/operator.py
+++ b/src/arroyo_reduction/operator.py
@@ -70,6 +70,9 @@ class LatentSpaceOperator(Operator):
                 return None
                 
             feature_vector = await asyncio.to_thread(self.reducer.reduce, message)
+            if feature_vector is None:
+                logger.info(f"Skipping frame {message.frame_number} due to processing error or model transition")
+                return None
             
             # Get the current model names from the reducer
             current_autoencoder = self.reducer.autoencoder_model_name

--- a/src/arroyo_reduction/publisher.py
+++ b/src/arroyo_reduction/publisher.py
@@ -69,8 +69,11 @@ class LSEWSResultPublisher(Publisher):
 
         if isinstance(message, LatentSpaceEvent):
             # send image data separately to client memory issues
-           
-            logger.debug(f"WS Sending LatentSpaceEvent {message.feature_vector}")
+            logger.debug(
+                f"WS Sending LatentSpaceEvent: vector={message.feature_vector}, "
+                f"autoencoder={message.autoencoder_model}, dimred={message.dimred_model}, "
+                f"index={message.index}, tiled_url={message.tiled_url}"
+            )
             await client.send(message.model_dump_json())
 
     async def websocket_handler(self, websocket):

--- a/src/arroyo_reduction/reducer.py
+++ b/src/arroyo_reduction/reducer.py
@@ -110,7 +110,7 @@ class LatentSpaceReducer(Reducer):
         if self.is_loading_model:
             logger.info(f"Waiting for {self.loading_model_type} model to finish loading...")
             # Return a placeholder while models are loading
-            return np.zeros((1, 2))  # Return empty vector during loading
+            return None 
             
         try:
             # Get numpy array from message
@@ -121,7 +121,7 @@ class LatentSpaceReducer(Reducer):
             
         except Exception as e:
             logger.error(f"Error in image preparation: {e}")
-            return np.zeros((1, 2))  # Return empty vector on error
+            return None 
         
         # Process with autoencoder to get latent features
         try:
@@ -132,7 +132,7 @@ class LatentSpaceReducer(Reducer):
             
         except Exception as e:
             logger.error(f"Error in autoencoder processing: {e}")
-            return np.zeros((1, 2))  # Return empty vector on error
+            return None  
         
         # Apply dimension reduction directly with latent features
         try:            
@@ -142,7 +142,7 @@ class LatentSpaceReducer(Reducer):
             return f_vec
         except Exception as e:
             logger.error(f"Error in dimension reduction: {e}")
-            return np.zeros((1, 2))  # Return empty vector on error
+            return None  
             
     
     def _subscribe_to_model_updates(self):

--- a/src/test/test_mlflow_client.py
+++ b/src/test/test_mlflow_client.py
@@ -1,68 +1,68 @@
-import pytest
-from unittest.mock import patch, MagicMock, call
-import os
 import hashlib
-import mlflow
+import os
+from unittest.mock import MagicMock, call, patch
 
-from src.test.test_utils import (
-    mock_mlflow_client, 
-    mock_os_makedirs,
-    mlflow_test_client
-)
+import mlflow
+import pytest
+
+from src.test.test_utils import mlflow_test_client, mock_mlflow_client, mock_os_makedirs
 from src.utils.mlflow_utils import MLflowClient
 
+
 class TestMLflowClient:
-    
+
     @pytest.fixture(autouse=True)
     def setup_and_teardown(self):
         """Reset MLflowClient._model_cache before and after each test"""
         # Save original cache
         original_cache = MLflowClient._model_cache.copy()
-        
+
         # Clear cache before test
         MLflowClient._model_cache = {}
-        
+
         yield
-        
+
         # Restore original cache after test
         MLflowClient._model_cache = original_cache
-    
+
     def test_init(self, mlflow_test_client, mock_os_makedirs):
         """Test initialization of MLflowClient"""
         client = mlflow_test_client
         # Verify environment variables were set
-        assert os.environ['MLFLOW_TRACKING_USERNAME'] == "test-user"
-        assert os.environ['MLFLOW_TRACKING_PASSWORD'] == "test-password"
-        
+        assert os.environ["MLFLOW_TRACKING_USERNAME"] == "test-user"
+        assert os.environ["MLFLOW_TRACKING_PASSWORD"] == "test-password"
+
         # Verify cache directory creation was attempted
         mock_os_makedirs.assert_called_with(client.cache_dir, exist_ok=True)
-    
+
     def test_check_mlflow_ready_success(self, mlflow_test_client, mock_mlflow_client):
         """Test check_mlflow_ready when MLflow is reachable"""
         client = mlflow_test_client
         # Configure the mock to return a result
         mock_mlflow_client.search_experiments.return_value = []
-        
+
         # Call the method
         result = client.check_mlflow_ready()
-        
+
         # Verify the result is True
         assert result is True
         mock_mlflow_client.search_experiments.assert_called_once_with(max_results=1)
-    
+
     def test_check_mlflow_ready_failure(self, mlflow_test_client, mock_mlflow_client):
         """Test check_mlflow_ready when MLflow is not reachable"""
         client = mlflow_test_client
         # Configure the mock to raise an exception
-        mock_mlflow_client.search_experiments.side_effect = Exception("Connection error")
-        
+        mock_mlflow_client.search_experiments.side_effect = Exception(
+            "Connection error"
+        )
+
         # Call the method
         result = client.check_mlflow_ready()
-        
+
         # Verify the result is False
         assert result is False
         mock_mlflow_client.search_experiments.assert_called_once_with(max_results=1)
-        
+
     def test_get_mlflow_params(self, mlflow_test_client, mock_mlflow_client):
         """Test retrieving MLflow model parameters"""
         client = mlflow_test_client
@@ -70,26 +70,25 @@ class TestMLflowClient:
         mock_model_version = MagicMock()
         mock_model_version.run_id = "run-123"
         mock_mlflow_client.get_model_version.return_value = mock_model_version
-        
+
         # Configure mock for get_run
         mock_run = MagicMock()
         mock_run.data.params = {"param1": "value1", "param2": "value2"}
         mock_mlflow_client.get_run.return_value = mock_run
-        
+
         result = client.get_mlflow_params("test-model")
-        
+
         # Verify get_model_version was called with the right parameters
         mock_mlflow_client.get_model_version.assert_called_once_with(
-            name="test-model",
-            version="1"
+            name="test-model", version="1"
         )
-        
+
         # Verify get_run was called with the right run ID
         mock_mlflow_client.get_run.assert_called_once_with("run-123")
-        
+
         # Verify the result contains the expected parameters
         assert result == {"param1": "value1", "param2": "value2"}
-    
+
     def test_get_mlflow_models(self, mlflow_test_client, mock_mlflow_client):
         """Test retrieving MLflow models"""
         client = mlflow_test_client
@@ -98,44 +97,54 @@ class TestMLflowClient:
         mock_version1.name = "model1"
         mock_version1.version = "1"
         mock_version1.run_id = "run1"
-        
+
         mock_version2 = MagicMock()
         mock_version2.name = "model2"
-        mock_version2.version = "2" 
+        mock_version2.version = "2"
         mock_version2.run_id = "run2"
-        
+
         # Configure search_model_versions to return our mock versions
         mock_mlflow_client.search_model_versions.return_value = [
-            mock_version1, mock_version2
+            mock_version1,
+            mock_version2,
         ]
-        
+
         # Configure runs with tags
         mock_run1 = MagicMock()
         mock_run1.data.tags = {"exp_type": "dev"}
-        
+
         mock_run2 = MagicMock()
         mock_run2.data.tags = {"exp_type": "test"}
-        
+
         # Configure get_run to return our mock runs
         mock_mlflow_client.get_run.side_effect = [mock_run1, mock_run2]
-        
+
         # Mock the get_flow_run_name and get_flow_run_parent_id functions
-        with patch('src.utils.mlflow_utils.get_flow_run_name', return_value="Flow Run 1"), \
-             patch('src.utils.mlflow_utils.get_flow_run_parent_id', return_value="parent-id"):
-            
+        with (
+            patch(
+                "src.utils.mlflow_utils.get_flow_run_name", return_value="Flow Run 1"
+            ),
+            patch(
+                "src.utils.mlflow_utils.get_flow_run_parent_id",
+                return_value="parent-id",
+            ),
+        ):
+
             result = client.get_mlflow_models()
-        
+
         # Verify search_model_versions was called
         mock_mlflow_client.search_model_versions.assert_called_once()
-        
+
         # Verify the result has the expected structure
         assert len(result) == 2
         assert result[0]["label"] == "Flow Run 1"
-        assert result[0]["value"] == "model1" 
+        assert result[0]["value"] == "model1"
         assert result[1]["label"] == "Flow Run 1"
         assert result[1]["value"] == "model2"
-    
-    def test_get_mlflow_models_with_livemode(self, mlflow_test_client, mock_mlflow_client):
+
+    def test_get_mlflow_models_with_livemode(
+        self, mlflow_test_client, mock_mlflow_client
+    ):
         """Test retrieving MLflow models with livemode=True"""
         client = mlflow_test_client
         # Create mock model versions
@@ -143,38 +152,41 @@ class TestMLflowClient:
         mock_version1.name = "model1"
         mock_version1.version = "1"
         mock_version1.run_id = "run1"
-        
+
         mock_version2 = MagicMock()
         mock_version2.name = "model2"
         mock_version2.version = "2"
         mock_version2.run_id = "run2"
-        
+
         # Configure search_model_versions to return our mock versions
         mock_mlflow_client.search_model_versions.return_value = [
-            mock_version1, mock_version2
+            mock_version1,
+            mock_version2,
         ]
-        
+
         # Configure runs with tags
         mock_run1 = MagicMock()
         mock_run1.data.tags = {"exp_type": "live_mode"}
-        
+
         mock_run2 = MagicMock()
         mock_run2.data.tags = {"exp_type": "dev"}
-        
+
         # Configure get_run to return our mock runs
         mock_mlflow_client.get_run.side_effect = [mock_run1, mock_run2]
-        
+
         result = client.get_mlflow_models(livemode=True)
-        
+
         # Verify search_model_versions was called
         mock_mlflow_client.search_model_versions.assert_called_once()
-        
+
         # Verify the result contains only models with exp_type="live_mode"
         assert len(result) == 1
         assert result[0]["label"] == "model1"
         assert result[0]["value"] == "model1"
-    
-    def test_get_mlflow_models_with_model_type(self, mlflow_test_client, mock_mlflow_client):
+
+    def test_get_mlflow_models_with_model_type(
+        self, mlflow_test_client, mock_mlflow_client
+    ):
         """Test retrieving MLflow models with model_type filter"""
         client = mlflow_test_client
         # Create mock model versions
@@ -182,38 +194,46 @@ class TestMLflowClient:
         mock_version1.name = "model1"
         mock_version1.version = "1"
         mock_version1.run_id = "run1"
-        
+
         mock_version2 = MagicMock()
         mock_version2.name = "model2"
         mock_version2.version = "2"
         mock_version2.run_id = "run2"
-        
+
         # Configure search_model_versions to return our mock versions
         mock_mlflow_client.search_model_versions.return_value = [
-            mock_version1, mock_version2
+            mock_version1,
+            mock_version2,
         ]
-        
+
         # Configure runs with tags
         mock_run1 = MagicMock()
         mock_run1.data.tags = {"exp_type": "dev", "model_type": "autoencoder"}
-        
+
         mock_run2 = MagicMock()
         mock_run2.data.tags = {"exp_type": "dev", "model_type": "dimension_reduction"}
-        
+
         # Configure get_run to return our mock runs
         mock_mlflow_client.get_run.side_effect = [mock_run1, mock_run2]
-        
+
         # Mock the get_flow_run_name and get_flow_run_parent_id functions
-        with patch('src.utils.mlflow_utils.get_flow_run_parent_id', return_value="parent-id"), \
-             patch('src.utils.mlflow_utils.get_flow_run_name', return_value="Flow Run 1"):
-            
+        with (
+            patch(
+                "src.utils.mlflow_utils.get_flow_run_parent_id",
+                return_value="parent-id",
+            ),
+            patch(
+                "src.utils.mlflow_utils.get_flow_run_name", return_value="Flow Run 1"
+            ),
+        ):
+
             result = client.get_mlflow_models(model_type="autoencoder")
-        
+
         # Verify the result contains only models with model_type "autoencoder"
         assert len(result) == 1
         assert result[0]["label"] == "Flow Run 1"
         assert result[0]["value"] == "model1"
-    
+
     def test_get_cache_path(self, mlflow_test_client):
         """Test the _get_cache_path method"""
         client = mlflow_test_client
@@ -221,24 +241,24 @@ class TestMLflowClient:
         cache_path = client._get_cache_path("test-model")
         expected_hash = hashlib.md5("test-model".encode()).hexdigest()
         assert cache_path == f"/tmp/test_mlflow_cache/test-model_{expected_hash}"
-        
+
         # Test with version
         cache_path = client._get_cache_path("test-model", 2)
         assert cache_path == "/tmp/test_mlflow_cache/test-model_v2"
-    
+
     def test_load_model_from_memory_cache(self, mlflow_test_client):
         """Test loading a model from memory cache"""
         client = mlflow_test_client
         # Set up memory cache
         mock_model = MagicMock(name="memory_model")
         MLflowClient._model_cache = {"test-model": mock_model}
-        
+
         # Load model
         result = client.load_model("test-model")
-        
+
         # Verify result is from cache
         assert result is mock_model
-    
+
     def test_load_model_from_disk_cache(self, mlflow_test_client, mock_mlflow_client):
         """Test loading a model from disk cache"""
         client = mlflow_test_client
@@ -246,44 +266,50 @@ class TestMLflowClient:
         mock_version = MagicMock()
         mock_version.version = "1"
         mock_mlflow_client.search_model_versions.return_value = [mock_version]
-        
+
         # Setup mock model
         mock_model = MagicMock(name="disk_cache_model")
-        
+
         # Test disk cache path
-        with patch('os.path.exists', return_value=True), \
-             patch('mlflow.pyfunc.load_model', return_value=mock_model):
-            
+        with (
+            patch("os.path.exists", return_value=True),
+            patch("mlflow.pyfunc.load_model", return_value=mock_model),
+        ):
+
             # Load model
             result = client.load_model("test-model")
-            
+
             # Verify result is the mock model
             assert result is mock_model
-    
-    def test_load_model_download_artifacts(self, mlflow_test_client, mock_mlflow_client):
+
+    def test_load_model_download_artifacts(
+        self, mlflow_test_client, mock_mlflow_client
+    ):
         """Test loading a model by downloading artifacts"""
         client = mlflow_test_client
         # Setup mocks
         mock_version = MagicMock()
         mock_version.version = "1"
         mock_mlflow_client.search_model_versions.return_value = [mock_version]
-        
+
         # Setup mock model
         mock_model = MagicMock(name="download_model")
         download_path = "/tmp/test_mlflow_cache/downloaded_model"
-        
+
         # Test artifact download path
-        with patch('os.path.exists', return_value=False), \
-             patch('os.makedirs'), \
-             patch('mlflow.artifacts.download_artifacts', return_value=download_path), \
-             patch('mlflow.pyfunc.load_model', return_value=mock_model):
-            
+        with (
+            patch("os.path.exists", return_value=False),
+            patch("os.makedirs"),
+            patch("mlflow.artifacts.download_artifacts", return_value=download_path),
+            patch("mlflow.pyfunc.load_model", return_value=mock_model),
+        ):
+
             # Load model
             result = client.load_model("test-model")
-            
+
             # Verify result is the mock model
             assert result is mock_model
-    
+
     def test_load_model_fallback(self, mlflow_test_client, mock_mlflow_client):
         """Test load_model fallback when download fails"""
         client = mlflow_test_client
@@ -291,71 +317,78 @@ class TestMLflowClient:
         mock_version = MagicMock()
         mock_version.version = "1"
         mock_mlflow_client.search_model_versions.return_value = [mock_version]
-        
+
         # Setup mock model
         mock_model = MagicMock(name="fallback_model")
-        
+
         # Test fallback path
-        with patch('os.path.exists', return_value=False), \
-             patch('os.makedirs'), \
-             patch('mlflow.artifacts.download_artifacts', side_effect=Exception("Download error")), \
-             patch('mlflow.pyfunc.load_model', return_value=mock_model):
-            
+        with (
+            patch("os.path.exists", return_value=False),
+            patch("os.makedirs"),
+            patch(
+                "mlflow.artifacts.download_artifacts",
+                side_effect=Exception("Download error"),
+            ),
+            patch("mlflow.pyfunc.load_model", return_value=mock_model),
+        ):
+
             # Load model
             result = client.load_model("test-model")
-            
+
             # Verify result is the mock model
             assert result is mock_model
-    
+
     def test_load_model_no_versions(self, mlflow_test_client, mock_mlflow_client):
         """Test loading a model when no versions are found"""
         client = mlflow_test_client
         # Configure client to return no versions
         mock_mlflow_client.search_model_versions.return_value = []
-        
+
         # Test no versions path - we don't need to patch mlflow.pyfunc.load_model
         # because it should never be called
         result = client.load_model("test-model")
-        
+
         # Verify result is None
         assert result is None
-    
+
     def test_load_model_error(self, mlflow_test_client, mock_mlflow_client):
         """Test error handling in load_model"""
         client = mlflow_test_client
         # Configure client to raise an exception
         mock_mlflow_client.search_model_versions.side_effect = Exception("Test error")
-        
+
         # Test error path - we don't need to patch mlflow.pyfunc.load_model
         # because it should never be called
         result = client.load_model("test-model")
-        
+
         # Verify result is None
         assert result is None
-    
+
     def test_clear_memory_cache(self):
         """Test clearing the memory cache"""
         # Set up memory cache
         MLflowClient._model_cache = {"test-model": MagicMock()}
-        
+
         # Clear memory cache
         MLflowClient.clear_memory_cache()
-        
+
         # Verify memory cache is empty
         assert len(MLflowClient._model_cache) == 0
-    
+
     def test_clear_disk_cache(self, mlflow_test_client):
         """Test clearing the disk cache"""
         client = mlflow_test_client
         # Mock shutil.rmtree and os.makedirs
-        with patch('shutil.rmtree') as mock_rmtree, \
-             patch('os.makedirs') as mock_makedirs:
-            
+        with (
+            patch("shutil.rmtree") as mock_rmtree,
+            patch("os.makedirs") as mock_makedirs,
+        ):
+
             # Clear disk cache
             client.clear_disk_cache()
-            
+
             # Verify rmtree was called with the cache directory
             mock_rmtree.assert_called_once_with(client.cache_dir)
-            
+
             # Verify makedirs was called with the cache directory
             mock_makedirs.assert_called_once_with(client.cache_dir, exist_ok=True)

--- a/src/test/test_model_callbacks.py
+++ b/src/test/test_model_callbacks.py
@@ -1,225 +1,196 @@
+# src/test/test_model_callbacks.py
+from unittest.mock import MagicMock, patch
+
 import pytest
-from unittest.mock import patch, MagicMock
-import json
 from dash.exceptions import PreventUpdate
 
-from src.test.test_utils import mock_redis_store, mock_mlflow_client, mock_logger
-from src.callbacks.execute import (
-    store_dialog_models_in_redis_on_continue, 
-    store_sidebar_models_in_redis_on_update
+from src.callbacks.live_mode import (
+    handle_model_continue,
+    reset_update_button,
+    update_live_models,
+)
+from src.test.test_utils import (
+    mock_live_mode_mlflow_client,
+    mock_logger,
+    mock_redis_store,
 )
 
+
 class TestModelCallbacks:
-    
-    @pytest.fixture
-    def patch_callbacks(self):
-        """Create a fixture to patch the actual functions with mocked versions"""
-        # Create mock implementations that match the actual return values
-        dialog_mock = MagicMock()
-        sidebar_mock = MagicMock()
-        
-        # Configure mocks to return expected values
-        dialog_mock.return_value = 1  # The actual function increments the counter
-        sidebar_mock.return_value = "secondary"  # The actual function returns the color value
-        
-        # Patch the functions
-        with patch('src.callbacks.execute.store_dialog_models_in_redis_on_continue', dialog_mock), \
-             patch('src.callbacks.execute.store_sidebar_models_in_redis_on_update', sidebar_mock):
-            yield {
-                "dialog": dialog_mock,
-                "sidebar": sidebar_mock
-            }
-    
-    def test_store_dialog_models_in_redis_on_continue(self, mock_redis_store, mock_logger, patch_callbacks):
-        """Test storing models from dialog in Redis when Continue button is clicked"""
-        # Test data
-        n_clicks = 1
-        autoencoder = "dialog_autoencoder"
-        dimred = "dialog_dimred"
-        counter = 5
-        
-        # Configure mock to return success
-        mock_redis_store.store_autoencoder_model.return_value = True
-        mock_redis_store.store_dimred_model.return_value = True
-        
-        # Call the patched function
-        mock_func = patch_callbacks["dialog"]
-        result = mock_func(n_clicks, autoencoder, dimred, counter)
-        
-        # Verify the correct function was called with right arguments
-        mock_func.assert_called_once_with(n_clicks, autoencoder, dimred, counter)
-        
-        # Return values will match what we configured in the fixture
-        assert result == 1
-    
-    def test_store_sidebar_models_in_redis_on_update(self, mock_redis_store, mock_logger, patch_callbacks):
-        """Test storing models from sidebar in Redis when Update button is clicked"""
-        # Test data
-        n_clicks = 1
-        autoencoder = "sidebar_autoencoder"
-        dimred = "sidebar_dimred"
-        counter = 10
-        
-        # Configure mock to return success
-        mock_redis_store.store_autoencoder_model.return_value = True
-        mock_redis_store.store_dimred_model.return_value = True
-        
-        # Call the patched function
-        mock_func = patch_callbacks["sidebar"]
-        result = mock_func(n_clicks, autoencoder, dimred, counter)
-        
-        # Verify the correct function was called with right arguments
-        mock_func.assert_called_once_with(n_clicks, autoencoder, dimred, counter)
-        
-        # Check that it returned the expected value
-        assert result == "secondary"
-    
-    def test_prevent_update_when_no_clicks_dialog(self):
-        """Test PreventUpdate is raised when n_clicks is None for dialog"""
-        # Direct patching of the function for this specific test
-        with patch('src.callbacks.execute.store_dialog_models_in_redis_on_continue', autospec=True) as mock_func:
-            # Set side_effect to raise PreventUpdate when called with None
-            mock_func.side_effect = PreventUpdate
-            
-            # Call the function within the pytest.raises context
-            with pytest.raises(PreventUpdate):
-                mock_func(None, "model1", "model2")
-    
-    def test_prevent_update_when_no_clicks_sidebar(self):
-        """Test PreventUpdate is raised when n_clicks is None for sidebar"""
-        # Direct patching of the function for this specific test
-        with patch('src.callbacks.execute.store_sidebar_models_in_redis_on_update', autospec=True) as mock_func:
-            # Set side_effect to raise PreventUpdate when called
-            mock_func.side_effect = PreventUpdate
-            
-            # Call the function within the pytest.raises context
-            with pytest.raises(PreventUpdate):
-                mock_func(None, "model1", "model2")
-    
-    def test_handle_redis_store_failure_dialog(self, mock_redis_store, mock_logger, patch_callbacks):
-        """Test behavior when Redis store operations fail for dialog"""
-        # Test data
-        n_clicks = 1
-        autoencoder = "dialog_autoencoder"
-        dimred = "dialog_dimred"
-        counter = 5
-        
-        # Configure mocks to simulate failure
-        mock_redis_store.store_autoencoder_model.return_value = False
-        mock_redis_store.store_dimred_model.return_value = True
-        
-        # Configure our mock to return a different value for failure
-        mock_func = patch_callbacks["dialog"]
-        mock_func.return_value = 0  # Changed to represent failure
-        
-        # Call function
-        result = mock_func(n_clicks, autoencoder, dimred, counter)
-        
-        # Verify result matches the failure value
-        assert result == 0
-    
-    def test_handle_redis_store_failure_sidebar(self, mock_redis_store, mock_logger, patch_callbacks):
-        """Test behavior when Redis store operations fail for sidebar"""
-        # Test data
-        n_clicks = 1
-        autoencoder = "sidebar_autoencoder"
-        dimred = "sidebar_dimred"
-        counter = 5
-        
-        # Configure mocks to simulate failure
-        mock_redis_store.store_autoencoder_model.return_value = True
-        mock_redis_store.store_dimred_model.return_value = False
-        
-        # Configure our mock to return a different value for failure
-        mock_func = patch_callbacks["sidebar"]
-        mock_func.return_value = 0  # Changed to match the expected value in test
-        
-        # Call function
-        result = mock_func(n_clicks, autoencoder, dimred, counter)
-        
-        # Verify result matches the failure value
-        assert result == 0
-    
-    def test_handle_exception_dialog(self, mock_redis_store, mock_logger, patch_callbacks):
-        """Test handling exceptions for dialog"""
-        # Configure Redis to raise an exception
-        mock_redis_store.store_autoencoder_model.side_effect = Exception("Test error")
-        
-        # Configure our mock to handle the exception
-        mock_func = patch_callbacks["dialog"]
-        mock_func.side_effect = lambda n_clicks, *args: (
-            PreventUpdate() if n_clicks is None else 
-            0  # Simulate error handling returning 0
+
+    def test_handle_model_continue(
+        self, mock_redis_store, mock_live_mode_mlflow_client
+    ):
+        """Test handling continue button with compatible models"""
+        # Setup
+        continue_clicks = 1
+        selected_auto = "compatible_auto"
+        selected_dimred = "compatible_dimred"
+        auto_options = [{"label": "Auto1", "value": "compatible_auto"}]
+        dimred_options = [{"label": "Dimred1", "value": "compatible_dimred"}]
+
+        # Configure compatibility check
+        mock_live_mode_mlflow_client.check_model_compatibility.return_value = True
+
+        # Mock plot functions to avoid errors
+        with (
+            patch("src.callbacks.live_mode.plot_empty_scatter", return_value={}),
+            patch("src.callbacks.live_mode.plot_empty_heatmap", return_value={}),
+        ):
+
+            # Execute
+            results = handle_model_continue(
+                continue_clicks,
+                selected_auto,
+                selected_dimred,
+                auto_options,
+                dimred_options,
+            )
+
+        # Verify
+        assert results[0] is False  # Dialog should close
+        assert results[1] == {
+            "autoencoder": selected_auto,
+            "dimred": selected_dimred,
+        }  # Models stored
+
+        # Verify Redis calls
+        mock_redis_store.store_autoencoder_model.assert_called_once_with(selected_auto)
+        mock_redis_store.store_dimred_model.assert_called_once_with(selected_dimred)
+
+    def test_handle_model_continue_incompatible(
+        self, mock_redis_store, mock_live_mode_mlflow_client
+    ):
+        """Test handling continue button with incompatible models"""
+        # Setup
+        continue_clicks = 1
+        selected_auto = "incompatible"
+        selected_dimred = "compatible_dimred"
+        auto_options = [{"label": "Auto1", "value": "incompatible"}]
+        dimred_options = [{"label": "Dimred1", "value": "compatible_dimred"}]
+
+        # Configure compatibility check
+        mock_live_mode_mlflow_client.check_model_compatibility.return_value = False
+
+        # Execute
+        # The implementation doesn't raise PreventUpdate, so we just call it normally
+        result = handle_model_continue(
+            continue_clicks,
+            selected_auto,
+            selected_dimred,
+            auto_options,
+            dimred_options,
         )
-        
-        # Call function with exception
-        result = mock_func(1, "model1", "model2", 5)
-        
-        # Verify result is the error return value
-        assert result == 0
-    
-    def test_handle_exception_sidebar(self, mock_redis_store, mock_logger, patch_callbacks):
-        """Test handling exceptions for sidebar"""
-        # Configure Redis to raise an exception
-        mock_redis_store.store_autoencoder_model.side_effect = Exception("Test error")
-        
-        # Configure our mock to handle the exception
-        mock_func = patch_callbacks["sidebar"]
-        mock_func.side_effect = lambda n_clicks, *args: (
-            PreventUpdate() if n_clicks is None else 
-            "danger"  # Simulate error handling returning "danger"
+
+        # Verify Redis calls were not made
+        mock_redis_store.store_autoencoder_model.assert_not_called()
+        mock_redis_store.store_dimred_model.assert_not_called()
+
+    def test_update_live_models(self, mock_redis_store, mock_live_mode_mlflow_client):
+        """Test updating models from sidebar"""
+        # Setup
+        n_clicks = 1
+        autoencoder = "test_autoencoder"
+        dimred = "test_dimred"
+        data_project_dict = {"root_uri": "", "datasets": []}
+
+        # Configure compatibility check
+        mock_live_mode_mlflow_client.check_model_compatibility.return_value = True
+
+        # Mock plot functions to avoid errors
+        with (
+            patch("src.callbacks.live_mode.plot_empty_scatter", return_value={}),
+            patch("src.callbacks.live_mode.plot_empty_heatmap", return_value={}),
+        ):
+
+            # Execute
+            results = update_live_models(
+                n_clicks, autoencoder, dimred, data_project_dict
+            )
+
+        # Verify
+        assert results[0] == {
+            "autoencoder": autoencoder,
+            "dimred": dimred,
+        }  # Selected models
+        assert "live_models" in results[1]  # Updated data project dict
+        assert results[1]["live_models"] == {
+            "autoencoder": autoencoder,
+            "dimred": dimred,
+        }
+
+        # Verify Redis calls
+        mock_redis_store.store_autoencoder_model.assert_called_once_with(autoencoder)
+        mock_redis_store.store_dimred_model.assert_called_once_with(dimred)
+
+    def test_update_live_models_failure(
+        self, mock_redis_store, mock_live_mode_mlflow_client, mock_logger
+    ):
+        """Test error handling when Redis operations fail"""
+        # Setup
+        n_clicks = 1
+        autoencoder = "test_autoencoder"
+        dimred = "test_dimred"
+        data_project_dict = {"root_uri": "", "datasets": []}
+
+        # Configure Redis failure
+        mock_redis_store.store_autoencoder_model.side_effect = Exception("Redis error")
+
+        # Execute
+        with (
+            patch("src.callbacks.live_mode.plot_empty_scatter", return_value={}),
+            patch("src.callbacks.live_mode.plot_empty_heatmap", return_value={}),
+        ):
+
+            results = update_live_models(
+                n_clicks, autoencoder, dimred, data_project_dict
+            )
+
+        # Verify error handling
+        assert results[2] == "danger"  # Button color should indicate error
+        assert (
+            results[3] == "Update Fail"
+        )  # Button text should match actual implementation
+
+        # Verify logger was called with error
+        mock_logger.error.assert_called()
+
+    def test_reset_update_button(self, mock_live_mode_mlflow_client):
+        """Test resetting the update button state"""
+        # Setup
+        autoencoder = "test_autoencoder"
+        dimred = "test_dimred"
+        selected_models = {"autoencoder": "old_autoencoder", "dimred": "old_dimred"}
+
+        # Configure compatibility check
+        mock_live_mode_mlflow_client.check_model_compatibility.return_value = True
+
+        # Execute - models changed
+        result_disabled, result_color, result_text = reset_update_button(
+            autoencoder, dimred, selected_models
         )
-        
-        # Call function with exception
-        result = mock_func(1, "model1", "model2", 5)
-        
-        # Verify result is the error return value
-        assert result == "danger"
-        
-    def test_partial_model_submission_dialog(self, mock_redis_store, patch_callbacks):
-        """Test behavior when only one model is provided for dialog"""
-        # Test data
-        n_clicks = 1
-        autoencoder = "dialog_autoencoder"
-        dimred = None  # No dimension reduction model
-        counter = 5
-        
-        # Configure mock
-        mock_redis_store.store_autoencoder_model.return_value = True
-        
-        # Configure our mock to return success
-        mock_func = patch_callbacks["dialog"]
-        mock_func.return_value = 1
-        
-        # Call the function
-        result = mock_func(n_clicks, autoencoder, dimred, counter)
-        
-        # Verify result is success value
-        assert result == 1
-        
-        # Verify the mock was called with the right arguments
-        mock_func.assert_called_once_with(n_clicks, autoencoder, dimred, counter)
-        
-    def test_partial_model_submission_sidebar(self, mock_redis_store, patch_callbacks):
-        """Test behavior when only one model is provided for sidebar"""
-        # Test data
-        n_clicks = 1
-        autoencoder = None  # No autoencoder model
-        dimred = "sidebar_dimred"
-        counter = 5
-        
-        # Configure mock
-        mock_redis_store.store_dimred_model.return_value = True
-        
-        # Configure our mock to return success
-        mock_func = patch_callbacks["sidebar"]
-        mock_func.return_value = 1  # Changed to match expected value in the test
-        
-        # Call the function
-        result = mock_func(n_clicks, autoencoder, dimred, counter)
-        
-        # Verify result matches the success value
-        assert result == 1
-        
-        # Verify the mock was called with the right arguments
-        mock_func.assert_called_once_with(n_clicks, autoencoder, dimred, counter)
+
+        # Verify - button should be enabled with primary color
+        assert result_disabled is False
+        assert result_color == "primary"
+        assert result_text == "Update Models"
+
+        # Execute - models unchanged
+        result_disabled, result_color, result_text = reset_update_button(
+            "old_autoencoder", "old_dimred", selected_models
+        )
+
+        # Verify - button should be disabled with secondary color
+        assert result_disabled is True
+        assert result_color == "secondary"
+        assert result_text == "Updated"
+
+        # Execute - incompatible models
+        mock_live_mode_mlflow_client.check_model_compatibility.return_value = False
+        result_disabled, result_color, result_text = reset_update_button(
+            "incompatible", dimred, selected_models
+        )
+
+        # Verify - based on actual implementation behavior
+        assert result_color == "danger"
+        assert result_text == "Incompatible Models"

--- a/src/test/test_redis_store.py
+++ b/src/test/test_redis_store.py
@@ -1,94 +1,98 @@
+import json
+from unittest.mock import MagicMock, patch
+
 import pytest
 import redis
-import json
-from unittest.mock import patch, MagicMock
 
-from src.test.test_utils import mock_redis_client, redis_test_store
 from src.arroyo_reduction.redis_model_store import RedisModelStore
+from src.test.test_utils import mock_redis_client, redis_test_store
+
 
 class TestRedisStore:
-    
+
     def test_store_and_get_models(self, redis_test_store):
         """Test storing and retrieving model names"""
         # Test data
         autoencoder_name = "test_autoencoder_model"
         dimred_name = "test_dimred_model"
-        
+
         # Configure mock to return our test data
         redis_test_store._mock_client.get.side_effect = [autoencoder_name, dimred_name]
-        
+
         # Store models
         redis_test_store.store_autoencoder_model(autoencoder_name)
         redis_test_store.store_dimred_model(dimred_name)
-        
+
         # Verify Redis set was called
         redis_test_store._mock_client.set.assert_any_call(
-            RedisModelStore.KEY_AUTOENCODER_MODEL, 
-            autoencoder_name
+            RedisModelStore.KEY_AUTOENCODER_MODEL, autoencoder_name
         )
         redis_test_store._mock_client.set.assert_any_call(
-            RedisModelStore.KEY_DIMRED_MODEL, 
-            dimred_name
+            RedisModelStore.KEY_DIMRED_MODEL, dimred_name
         )
-        
+
         # Get models and verify
         retrieved_autoencoder = redis_test_store.get_autoencoder_model()
         retrieved_dimred = redis_test_store.get_dimred_model()
-        
+
         assert retrieved_autoencoder == autoencoder_name
         assert retrieved_dimred == dimred_name
-        
+
         # Verify get was called
-        redis_test_store._mock_client.get.assert_any_call(RedisModelStore.KEY_AUTOENCODER_MODEL)
-        redis_test_store._mock_client.get.assert_any_call(RedisModelStore.KEY_DIMRED_MODEL)
-    
+        redis_test_store._mock_client.get.assert_any_call(
+            RedisModelStore.KEY_AUTOENCODER_MODEL
+        )
+        redis_test_store._mock_client.get.assert_any_call(
+            RedisModelStore.KEY_DIMRED_MODEL
+        )
+
     def test_publish_model_update(self, redis_test_store):
         """Test pub/sub functionality"""
         model_type = "autoencoder"
         model_name = "new_model"
-        
+
         # Mock publish to return 1 (one client received the message)
         redis_test_store._mock_client.publish.return_value = 1
-        
+
         # Publish an update
         result = redis_test_store.publish_model_update(model_type, model_name)
-        
+
         # Verify result
         assert result is True
-        
+
         # Verify publish was called
         redis_test_store._mock_client.publish.assert_called_once()
-        
+
         # Check channel and message format
         args = redis_test_store._mock_client.publish.call_args[0]
         assert args[0] == RedisModelStore.CHANNEL_MODEL_UPDATES
-        
+
         # Parse and check message
         message = json.loads(args[1])
         assert message["model_type"] == model_type
         assert message["model_name"] == model_name
         assert "timestamp" in message
-        
+
     def test_subscribe_to_model_updates(self, redis_test_store):
         """Test subscribing to model updates"""
         # Set up mocks
         mock_thread = MagicMock()
         mock_thread_cls = MagicMock(return_value=mock_thread)
-        
+
         # Set up callback
         callback = MagicMock()
-        
+
         # Call the function
-        with patch('threading.Thread', mock_thread_cls):
+        with patch("threading.Thread", mock_thread_cls):
             redis_test_store.subscribe_to_model_updates(callback)
-            
+
             # Verify thread was created and started
             mock_thread_cls.assert_called_once()
             assert mock_thread_cls.call_args[1]["daemon"] is True
-            
+
             # Get the thread target function
             thread_target = mock_thread_cls.call_args[1]["target"]
             assert callable(thread_target)
-            
+
             # Verify thread was started
             mock_thread.start.assert_called_once()

--- a/src/test/test_reducer.py
+++ b/src/test/test_reducer.py
@@ -1,141 +1,153 @@
-import pytest
+from unittest.mock import MagicMock, patch
+
 import numpy as np
+import pytest
 import torch
-from unittest.mock import patch, MagicMock
 
 from src.test.test_utils import mock_event, redis_mlflow_mocks
 
+
 class TestReducer:
-    
+
     @pytest.fixture
     def reducer(self, redis_mlflow_mocks):
         """Create a LatentSpaceReducer with all dependencies mocked"""
         # Patch _subscribe_to_model_updates to avoid threading issues
-        with patch('src.arroyo_reduction.reducer.LatentSpaceReducer._subscribe_to_model_updates'):
+        with patch(
+            "src.arroyo_reduction.reducer.LatentSpaceReducer._subscribe_to_model_updates"
+        ):
             # Import here after mocks are set up
             from src.arroyo_reduction.reducer import LatentSpaceReducer
-            
+
             # Create the reducer with all dependencies mocked
             reducer = LatentSpaceReducer()
-            
+
             # Set references to the mock models
             reducer.current_torch_model = redis_mlflow_mocks["autoencoder"]
             reducer.current_dim_reduction_model = redis_mlflow_mocks["dimred"]
-            
+
             # Store test data
-            reducer._test_data = {
-                "mocks": redis_mlflow_mocks
-            }
-            
+            reducer._test_data = {"mocks": redis_mlflow_mocks}
+
             return reducer
-    
+
     def test_reduce(self, reducer, mock_event, redis_mlflow_mocks):
         """Test that reduce() correctly processes an image through models"""
         # Get the mocks
         mocks = redis_mlflow_mocks
-        
+
         # Create real numpy arrays with proper dimensions and types
         latent_features = np.random.rand(1, 64).astype(np.float32)
         umap_coords = np.random.rand(1, 2).astype(np.float32)
-        
+
         # Set up the mocks to return real numpy arrays
         mocks["autoencoder"].predict.return_value = {"latent_features": latent_features}
         mocks["dimred"].predict.return_value = {"umap_coords": umap_coords}
-        
+
         # Set the models
         reducer.current_torch_model = mocks["autoencoder"]
         reducer.current_dim_reduction_model = mocks["dimred"]
-        
+
         # Mock logger to prevent logging issues
-        with patch('src.arroyo_reduction.reducer.logger'):
+        with patch("src.arroyo_reduction.reducer.logger"):
             # Call reduce()
             result = reducer.reduce(mock_event)
-        
+
         # Verify the processing flow
-        
+
         # 1. The autoencoder should be called with the correct input
         mocks["autoencoder"].predict.assert_called_once()
-        
+
         # 2. The dimred model should be called with the latent features
         mocks["dimred"].predict.assert_called_once_with(latent_features)
-        
+
         # 3. The result should be the actual numpy array from the mocked umap_coords
         assert isinstance(result, np.ndarray)
         assert result.shape == (1, 2)  # Check expected shape of UMAP coordinates
         # Verify it's actually the same array we created
         np.testing.assert_array_equal(result, umap_coords)
-    
+
     def test_reduce_during_model_loading(self, reducer, mock_event):
-        """Test that reduce() returns zeros when models are loading"""
+        """Test that reduce() returns None when models are loading"""
         # Set loading flag to True to simulate model loading
         reducer.is_loading_model = True
         reducer.loading_model_type = "autoencoder"
-        
+
         # Mock logger to prevent logging issues
-        with patch('src.arroyo_reduction.reducer.logger'):
+        with patch("src.arroyo_reduction.reducer.logger"):
             # Call reduce()
             result = reducer.reduce(mock_event)
-        
-        # Verify result is zeros of correct shape
-        assert isinstance(result, np.ndarray)
-        assert result.shape == (1, 2)
-        assert np.all(result == 0)
-    
+
+        # Verify result is None when models are loading
+        assert result is None
+        # Models should not be called
+        reducer.current_torch_model.predict.assert_not_called()
+        reducer.current_dim_reduction_model.predict.assert_not_called()
+
     def test_init_loads_models_from_redis(self):
         """Test that constructor loads models from Redis"""
         # Create mocks for dependencies
-        with patch('src.arroyo_reduction.redis_model_store.RedisModelStore', autospec=True) as redis_class_mock, \
-             patch('src.utils.mlflow_utils.MLflowClient') as mlflow_client_mock, \
-             patch('src.arroyo_reduction.reducer.LatentSpaceReducer._subscribe_to_model_updates'), \
-             patch('src.arroyo_reduction.reducer.logger'):
-            
+        with (
+            patch(
+                "src.arroyo_reduction.redis_model_store.RedisModelStore", autospec=True
+            ) as redis_class_mock,
+            patch("src.utils.mlflow_utils.MLflowClient") as mlflow_client_mock,
+            patch(
+                "src.arroyo_reduction.reducer.LatentSpaceReducer._subscribe_to_model_updates"
+            ),
+            patch("src.arroyo_reduction.reducer.logger"),
+        ):
+
             # Set up mock store - important to do this before importing
             mock_store = MagicMock()
             redis_class_mock.return_value = mock_store
             mock_store.get_autoencoder_model.return_value = "test_autoencoder"
             mock_store.get_dimred_model.return_value = "test_dimred"
-            
+
             # Set up mock MLflowClient
             mock_mlflow_client = MagicMock()
             mlflow_client_mock.return_value = mock_mlflow_client
-            
+
             # Set up mock models
             mock_autoencoder = MagicMock()
             mock_dimred = MagicMock()
-            
+
             # Configure the load_model method
-            mock_mlflow_client.load_model.side_effect = lambda name: mock_autoencoder if name == "test_autoencoder" else mock_dimred
-            
+            mock_mlflow_client.load_model.side_effect = lambda name: (
+                mock_autoencoder if name == "test_autoencoder" else mock_dimred
+            )
+
             # Import the real class - this needs to be done AFTER setting up the mocks
             # to ensure the imports in the module use our mocked objects
             import sys
-            if 'src.arroyo_reduction.reducer' in sys.modules:
-                del sys.modules['src.arroyo_reduction.reducer']
-            
+
+            if "src.arroyo_reduction.reducer" in sys.modules:
+                del sys.modules["src.arroyo_reduction.reducer"]
+
             # Now import the module fresh
             from src.arroyo_reduction.reducer import LatentSpaceReducer
-            
+
             # Create the reducer
             reducer = LatentSpaceReducer()
-            
+
             # Verify RedisModelStore was instantiated
             redis_class_mock.assert_called()
-            
+
             # Verify models were requested
             mock_store.get_autoencoder_model.assert_called()
             mock_store.get_dimred_model.assert_called()
-            
+
             # Verify MLflowClient was instantiated
             mlflow_client_mock.assert_called()
-            
+
             # Verify models were loaded
             mock_mlflow_client.load_model.assert_any_call("test_autoencoder")
             mock_mlflow_client.load_model.assert_any_call("test_dimred")
-            
+
             # Verify loading flags are set correctly during initialization
             assert not reducer.is_loading_model
             assert reducer.loading_model_type is None
-    
+
     def test_handle_model_update(self):
         """Test handling model update notifications"""
         # Set up mock models
@@ -143,237 +155,250 @@ class TestReducer:
         mock_new_autoencoder = MagicMock()
         mock_orig_dimred = MagicMock()
         mock_new_dimred = MagicMock()
-        
+
         # Create the patch for MLflowClient and redis before importing anything
-        with patch('src.utils.mlflow_utils.MLflowClient') as mlflow_client_mock, \
-             patch('src.arroyo_reduction.redis_model_store.RedisModelStore') as redis_mock, \
-             patch('src.arroyo_reduction.reducer.LatentSpaceReducer._subscribe_to_model_updates'), \
-             patch('src.arroyo_reduction.reducer.logger'):  # Add logger patch to suppress errors
-                
+        with (
+            patch("src.utils.mlflow_utils.MLflowClient") as mlflow_client_mock,
+            patch(
+                "src.arroyo_reduction.redis_model_store.RedisModelStore"
+            ) as redis_mock,
+            patch(
+                "src.arroyo_reduction.reducer.LatentSpaceReducer._subscribe_to_model_updates"
+            ),
+            patch("src.arroyo_reduction.reducer.logger"),
+        ):  # Add logger patch to suppress errors
+
             # Configure MLflowClient mock
             mock_mlflow_client = MagicMock()
             mlflow_client_mock.return_value = mock_mlflow_client
-            
+
             # Configure load_model to return different models based on name
             mock_mlflow_client.load_model.side_effect = lambda name: {
                 "test_autoencoder": mock_orig_autoencoder,
                 "new_autoencoder": mock_new_autoencoder,
                 "test_dimred": mock_orig_dimred,
-                "new_dimred": mock_new_dimred
+                "new_dimred": mock_new_dimred,
             }.get(name, MagicMock())
-                    
+
             # Set up mock store
             mock_store = MagicMock()
             redis_mock.return_value = mock_store
             mock_store.get_autoencoder_model.return_value = "test_autoencoder"
             mock_store.get_dimred_model.return_value = "test_dimred"
-            
+
             # Import the real class - ensure we have a fresh import
             import sys
-            if 'src.arroyo_reduction.reducer' in sys.modules:
-                del sys.modules['src.arroyo_reduction.reducer']
-            
+
+            if "src.arroyo_reduction.reducer" in sys.modules:
+                del sys.modules["src.arroyo_reduction.reducer"]
+
             from src.arroyo_reduction.reducer import LatentSpaceReducer
-            
+
             # Create the reducer - which loads the initial models
             reducer = LatentSpaceReducer()
-            
+
             # Add mlflow_client attribute with load_model method
             reducer.mlflow_client = mock_mlflow_client
-            
+
             # Verify initial models were loaded
             assert reducer.autoencoder_model_name == "test_autoencoder"
             assert reducer.dimred_model_name == "test_dimred"
-            
+
             # Create update messages
             autoencoder_update = {
                 "model_type": "autoencoder",
-                "model_name": "new_autoencoder"
+                "model_name": "new_autoencoder",
             }
-            
+
             # Handle autoencoder update
             reducer._handle_model_update(autoencoder_update)
-            
+
             # Verify model name was updated
             assert reducer.autoencoder_model_name == "new_autoencoder"
-            
+
             # Verify the mlflow_client.load_model was called with the new name
             mock_mlflow_client.load_model.assert_any_call("new_autoencoder")
-            
+
             # Create update for dimred model
-            dimred_update = {
-                "model_type": "dimred",
-                "model_name": "new_dimred"
-            }
-            
+            dimred_update = {"model_type": "dimred", "model_name": "new_dimred"}
+
             # Handle dimred update
             reducer._handle_model_update(dimred_update)
-            
+
             # Verify dimred model name was updated
             assert reducer.dimred_model_name == "new_dimred"
-            
+
             # Verify mlflow_client.load_model was called with the new dimred name
             mock_mlflow_client.load_model.assert_any_call("new_dimred")
-            
+
             # Test with invalid update
-            invalid_update = {
-                "model_type": "unknown",
-                "model_name": "test"
-            }
+            invalid_update = {"model_type": "unknown", "model_name": "test"}
             reducer._handle_model_update(invalid_update)
-            
+
             # Verify no changes with invalid update
             assert reducer.autoencoder_model_name == "new_autoencoder"
             assert reducer.dimred_model_name == "new_dimred"
-    
+
     def test_handle_duplicate_model_update(self):
         """Test handling duplicate model update notifications"""
         # Create the patch for MLflowClient and redis before importing anything
-        with patch('src.utils.mlflow_utils.MLflowClient') as mlflow_client_mock, \
-             patch('src.arroyo_reduction.redis_model_store.RedisModelStore') as redis_mock, \
-             patch('src.arroyo_reduction.reducer.LatentSpaceReducer._subscribe_to_model_updates'):
-                
+        with (
+            patch("src.utils.mlflow_utils.MLflowClient") as mlflow_client_mock,
+            patch(
+                "src.arroyo_reduction.redis_model_store.RedisModelStore"
+            ) as redis_mock,
+            patch(
+                "src.arroyo_reduction.reducer.LatentSpaceReducer._subscribe_to_model_updates"
+            ),
+        ):
+
             # Configure MLflowClient mock
             mock_mlflow_client = MagicMock()
             mlflow_client_mock.return_value = mock_mlflow_client
-            
+
             # Set up mock store
             mock_store = MagicMock()
             redis_mock.return_value = mock_store
             mock_store.get_autoencoder_model.return_value = "test_autoencoder"
             mock_store.get_dimred_model.return_value = "test_dimred"
-            
+
             # Import the real class - ensure we have a fresh import
             import sys
-            if 'src.arroyo_reduction.reducer' in sys.modules:
-                del sys.modules['src.arroyo_reduction.reducer']
-            
+
+            if "src.arroyo_reduction.reducer" in sys.modules:
+                del sys.modules["src.arroyo_reduction.reducer"]
+
             from src.arroyo_reduction.reducer import LatentSpaceReducer
-            
+
             # Create the reducer - which loads the initial models
             reducer = LatentSpaceReducer()
-            
+
             # Add mlflow_client attribute with load_model method
             reducer.mlflow_client = mock_mlflow_client
-            
+
             # Reset mock_mlflow_client to clear call history
             mock_mlflow_client.reset_mock()
-            
+
             # Create duplicate update message (same as current model)
             duplicate_update = {
                 "model_type": "autoencoder",
-                "model_name": "test_autoencoder"  # Same as current model
+                "model_name": "test_autoencoder",  # Same as current model
             }
-            
+
             # Track the initial state
             initial_autoencoder = reducer.autoencoder_model_name
             initial_dimred = reducer.dimred_model_name
-            
+
             # Handle duplicate update
             reducer._handle_model_update(duplicate_update)
-            
+
             # Key assertions for deduplication:
             # 1. Model names should not change
             assert reducer.autoencoder_model_name == initial_autoencoder
             assert reducer.dimred_model_name == initial_dimred
-            
+
             # 2. Most importantly, load_model should NOT be called for duplicates
             mock_mlflow_client.load_model.assert_not_called()
-            
+
             # Verify the model was NOT reloaded
             mock_mlflow_client.load_model.assert_not_called()
-            
+
             # Verify model names were not changed
             assert reducer.autoencoder_model_name == "test_autoencoder"
             assert reducer.dimred_model_name == "test_dimred"
-    
+
     def test_loading_flags_during_model_update(self):
         """Test that loading flags are set and reset correctly during model update"""
         # Create the patch for MLflowClient and redis before importing anything
-        with patch('src.utils.mlflow_utils.MLflowClient') as mlflow_client_mock, \
-             patch('src.arroyo_reduction.redis_model_store.RedisModelStore') as redis_mock, \
-             patch('src.arroyo_reduction.reducer.LatentSpaceReducer._subscribe_to_model_updates'), \
-             patch('src.arroyo_reduction.reducer.logger'):
-                
+        with (
+            patch("src.utils.mlflow_utils.MLflowClient") as mlflow_client_mock,
+            patch(
+                "src.arroyo_reduction.redis_model_store.RedisModelStore"
+            ) as redis_mock,
+            patch(
+                "src.arroyo_reduction.reducer.LatentSpaceReducer._subscribe_to_model_updates"
+            ),
+            patch("src.arroyo_reduction.reducer.logger"),
+        ):
+
             # Configure MLflowClient mock
             mock_mlflow_client = MagicMock()
             mlflow_client_mock.return_value = mock_mlflow_client
-            
+
             # Set up mock store
             mock_store = MagicMock()
             redis_mock.return_value = mock_store
             mock_store.get_autoencoder_model.return_value = "test_autoencoder"
             mock_store.get_dimred_model.return_value = "test_dimred"
-            
+
             # Import the real class
             from src.arroyo_reduction.reducer import LatentSpaceReducer
-            
+
             # Create the reducer
             reducer = LatentSpaceReducer()
-            
+
             # Add mlflow_client attribute
             reducer.mlflow_client = mock_mlflow_client
-            
+
             # Create test update message
-            update = {
-                "model_type": "autoencoder",
-                "model_name": "new_autoencoder"
-            }
-            
+            update = {"model_type": "autoencoder", "model_name": "new_autoencoder"}
+
             # Mock the flags to verify they're being set correctly
             reducer.is_loading_model = False
             reducer.loading_model_type = None
-            
+
             # Handle the update - this should set the flags to True during loading
             reducer._handle_model_update(update)
-            
+
             # Verify flags are reset to False after loading completes
             assert reducer.is_loading_model == False
             assert reducer.loading_model_type == None
-            
+
             # Test with exception during model loading
             mock_mlflow_client.load_model.side_effect = Exception("Test error")
-            
+
             # Reset flags
             reducer.is_loading_model = False
             reducer.loading_model_type = None
-            
+
             # Handle update with error - should still reset flags
             reducer._handle_model_update(update)
-            
+
             # Verify flags are reset even after exception
             assert reducer.is_loading_model == False
             assert reducer.loading_model_type == None
-    
+
     def test_subscribe_to_model_updates(self):
         """Test subscribing to model updates"""
         # Create a mock thread class and instance
         mock_thread = MagicMock()
-        
+
         # Test with just the thread mocked
-        with patch('threading.Thread', return_value=mock_thread) as mock_thread_class, \
-             patch('src.arroyo_reduction.redis_model_store.RedisModelStore'), \
-             patch('src.utils.mlflow_utils.MLflowClient'):
-            
+        with (
+            patch("threading.Thread", return_value=mock_thread) as mock_thread_class,
+            patch("src.arroyo_reduction.redis_model_store.RedisModelStore"),
+            patch("src.utils.mlflow_utils.MLflowClient"),
+        ):
+
             # Import the real class but patch the __init__ to avoid complex initialization
             from src.arroyo_reduction.reducer import LatentSpaceReducer
-            
-            with patch.object(LatentSpaceReducer, '__init__', return_value=None):
+
+            with patch.object(LatentSpaceReducer, "__init__", return_value=None):
                 # Create the reducer without calling __init__
                 reducer = LatentSpaceReducer()
-                
+
                 # Mock any necessary attributes
                 reducer.autoencoder_model_name = "test_autoencoder"
                 reducer.dimred_model_name = "test_dimred"
-                
+
                 # Call the method directly
                 reducer._subscribe_to_model_updates()
-                
+
                 # Verify thread was created with expected parameters
                 mock_thread_class.assert_called_once()
                 args, kwargs = mock_thread_class.call_args
-                assert kwargs['daemon'] is True
-                assert 'target' in kwargs
-                
+                assert kwargs["daemon"] is True
+                assert "target" in kwargs
+
                 # Verify thread was started
                 mock_thread.start.assert_called_once()

--- a/src/test/test_utils.py
+++ b/src/test/test_utils.py
@@ -1,34 +1,40 @@
 import os
+from unittest.mock import MagicMock, patch
+
 import pytest
-from unittest.mock import patch, MagicMock
+
 
 # Common fixtures for MLflow testing
 @pytest.fixture
 def mock_mlflow_client():
     """Mock MlflowClient class"""
-    with patch('src.utils.mlflow_utils.MlflowClient') as mock_client_class:
+    with patch("src.utils.mlflow_utils.MlflowClient") as mock_client_class:
         mock_client = MagicMock()
         mock_client_class.return_value = mock_client
         yield mock_client
 
+
 @pytest.fixture
 def mock_os_makedirs():
     """Mock os.makedirs to avoid file system errors"""
-    with patch('os.makedirs') as mock_makedirs:
+    with patch("os.makedirs") as mock_makedirs:
         yield mock_makedirs
+
 
 @pytest.fixture
 def mlflow_test_client(mock_mlflow_client, mock_os_makedirs):
     """Create a MLflowClient instance with mocked dependencies"""
-    with patch('mlflow.set_tracking_uri'):  # Avoid actually setting tracking URI
+    with patch("mlflow.set_tracking_uri"):  # Avoid actually setting tracking URI
         from src.utils.mlflow_utils import MLflowClient
+
         client = MLflowClient(
             tracking_uri="http://mock-mlflow:5000",
             username="test-user",
             password="test-password",
-            cache_dir="/tmp/test_mlflow_cache"
+            cache_dir="/tmp/test_mlflow_cache",
         )
         return client
+
 
 # Common fixtures for Redis testing
 @pytest.fixture
@@ -36,74 +42,84 @@ def mock_redis_client():
     """Create a mock Redis client"""
     return MagicMock()
 
+
+# Updated for live_mode callbacks instead of execute
 @pytest.fixture
 def mock_redis_store():
     """Mock the RedisModelStore"""
-    with patch('src.callbacks.execute.redis_model_store') as mock_store:
+    with patch("src.callbacks.live_mode.redis_model_store") as mock_store:
         yield mock_store
+
 
 @pytest.fixture
 def redis_test_store(mock_redis_client):
     """Create a RedisModelStore with a mock Redis client"""
     # Patch redis.Redis to return our mock
-    with patch('redis.Redis', return_value=mock_redis_client):
+    with patch("redis.Redis", return_value=mock_redis_client):
         from src.arroyo_reduction.redis_model_store import RedisModelStore
+
         # Create the store - this will use our patched Redis
         store = RedisModelStore(host="localhost", port=6379)
-        
+
         # Make sure our mock was used
         assert store.redis_client is mock_redis_client
-        
+
         # Store the mock for tests to use
         store._mock_client = mock_redis_client
-        
+
         yield store
+
 
 # Common fixtures for reducer testing
 @pytest.fixture
 def mock_event():
     """Create a mock event with image data"""
     import numpy as np
+
     event = MagicMock()
     # Create test image array with proper shape and dtype
     event.image.array = np.random.randint(0, 255, (512, 512, 3), dtype=np.uint8)
     return event
 
+
 @pytest.fixture
 def redis_mlflow_mocks():
     """Set up and start Redis and MLflow mocks"""
     # Create the patches
-    redis_mock_patch = patch('src.arroyo_reduction.redis_model_store.RedisModelStore')
-    mlflow_client_mock_patch = patch('src.utils.mlflow_utils.MLflowClient')
-    
+    redis_mock_patch = patch("src.arroyo_reduction.redis_model_store.RedisModelStore")
+    mlflow_client_mock_patch = patch("src.utils.mlflow_utils.MLflowClient")
+
     # Start all the patches
     redis_mock = redis_mock_patch.start()
     mlflow_client_mock = mlflow_client_mock_patch.start()
-    
+
     # Configure the Redis mock
     mock_store = MagicMock()
     redis_mock.return_value = mock_store
     mock_store.get_autoencoder_model.return_value = "test_autoencoder"
     mock_store.get_dimred_model.return_value = "test_dimred"
-    
+
     # Configure the MLFlow mock
     mock_mlflow_client = MagicMock()
     mlflow_client_mock.return_value = mock_mlflow_client
-    
+
     # Configure models to return test data
     import numpy as np
+
     latent_features = np.random.rand(1, 64).astype(np.float32)
     umap_coords = np.random.rand(1, 2).astype(np.float32)
-    
+
     mock_autoencoder = MagicMock()
     mock_dimred = MagicMock()
-    
+
     mock_autoencoder.predict.return_value = {"latent_features": latent_features}
     mock_dimred.predict.return_value = {"umap_coords": umap_coords}
-    
+
     # Configure the load_model method to return appropriate models
-    mock_mlflow_client.load_model.side_effect = lambda model_name: mock_autoencoder if model_name == "test_autoencoder" else mock_dimred
-    
+    mock_mlflow_client.load_model.side_effect = lambda model_name: (
+        mock_autoencoder if model_name == "test_autoencoder" else mock_dimred
+    )
+
     # Store all mocks and test data in a dict
     mocks = {
         "redis": redis_mock,
@@ -112,18 +128,31 @@ def redis_mlflow_mocks():
         "autoencoder": mock_autoencoder,
         "dimred": mock_dimred,
         "latent_features": latent_features,
-        "umap_coords": umap_coords
+        "umap_coords": umap_coords,
     }
-    
+
     yield mocks
-    
+
     # Stop all patches after the test
     redis_mock_patch.stop()
     mlflow_client_mock_patch.stop()
 
-# Common fixtures for model callback testing
+
+# Common fixtures for model callback testing - updated for live_mode
 @pytest.fixture
 def mock_logger():
     """Mock the logger"""
-    with patch('src.callbacks.execute.logger') as mock_logger:
+    with patch("src.callbacks.live_mode.logger") as mock_logger:
         yield mock_logger
+
+
+# Add a specific mock for the live_mode MLflow client
+@pytest.fixture
+def mock_live_mode_mlflow_client():
+    """Mock MLflowClient for live_mode callbacks"""
+    with patch("src.callbacks.live_mode.mlflow_client") as mock_client:
+        # Configure check_model_compatibility for testing
+        mock_client.check_model_compatibility.side_effect = (
+            lambda auto, dimred: auto and dimred and auto != "incompatible"
+        )
+        yield mock_client

--- a/src/utils/mlflow_utils.py
+++ b/src/utils/mlflow_utils.py
@@ -59,6 +59,35 @@ class MLflowClient:
         # Create client
         self.client = MlflowClient()
 
+    def check_model_compatibility(self, autoencoder_model, dim_reduction_model):
+        """
+        Check if autoencoder and dimension reduction models are compatible.
+        
+        Models are compatible if autoencoder latent_dim matches dimension reduction input_dim.
+        
+        Args:
+            autoencoder_model (str): The autoencoder model ID or name
+            dim_reduction_model (str): The dimension reduction model ID or name
+            
+        Returns:
+            bool: True if models are compatible, False otherwise
+        """
+        if not autoencoder_model or not dim_reduction_model:
+            return False
+        
+        # Check dimension compatibility
+        try:
+            auto_params = self.get_mlflow_params(autoencoder_model)
+            dimred_params = self.get_mlflow_params(dim_reduction_model)
+            
+            auto_dim = int(auto_params.get("latent_dim", 0))
+            dimred_dim = int(dimred_params.get("input_dim", 0))
+            
+            return auto_dim > 0 and auto_dim == dimred_dim
+        except Exception as e:
+            logger.warning(f"Error checking dimensions: {e}")
+            return False
+        
     def check_mlflow_ready(self):
         """
         Check if MLflow server is reachable by performing a lightweight API call.


### PR DESCRIPTION
### Main Changes

1. Added `vae_wrapper.py` to `live_operator_example/`. You can now set `AUTOENCODER_TYPE` in the .`env` file to choose whether `save_mlflow_wrapper.py` logs **VIT** or **VAE** models, along with their corresponding UMAP models.

2. Added model compatibility check in `mlflow_utils.py`: currently, this is a rough check — if the `latent_dim` of the autoencoder model equals the `input_dim` of the UMAP model, they are considered **compatible**.

3. Updated callbacks for `Continue` and `Update` buttons in the dialogue/sidebar: if the selected models in the dropdown are incompatible, the buttons are disabled, styled in red, and show the message _Incompatible Models_.

4. Removed `store_dialog_models_in_redis_on_continue` and `store_sidebar_models_in_redis_on_update` from `execute.py`, since their logic was redundant. Their functionality has been merged into `update_live_models` and `reset_update_button` in `live_mode.py`.



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210849430527533