### PR TITLE
Tiled_publish

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 TILED_SINGLE_USER_API_KEY=<unique api key>
+REMOTE_TILED_SINGLE_USER_API_KEY=<unique api key>
 
 PREFECT_DB_PW=<unique password>
 PREFECT_DB_USER=prefect_user
@@ -22,6 +23,7 @@ WRITE_DIR=/path/to/write/results
 DEFAULT_TILED_URI=http://tiled:8000
 DEFAULT_TILED_SUB_URI=
 DATA_TILED_KEY=<your_data_tiled_key>
+REMOTE_DATA_TILED_KEY=<remote_data_tiled_key>
 RESULTS_TILED_URI=http://tiled:8000
 RESULTS_TILED_API_KEY=<your_results_tiled_key>
 
@@ -71,3 +73,4 @@ NUMBA_CPU_FEATURES=+neon
 
 #MLflow URI for logging wrapped ML models
 MLFLOW_TRACKING_URI_OUTSIDE=http://localhost:5000
+MLFLOW_TRACKING_INSECURE_TLS="true"

--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 TILED_SINGLE_USER_API_KEY=<unique api key>
+TILED_ENV="prod" #use dev or prod
 REMOTE_TILED_SINGLE_USER_API_KEY=<unique api key>
 
 PREFECT_DB_PW=<unique password>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -263,6 +263,7 @@ services:
     volumes:
       - ./data/vector_db_smi:/data/vector_db_smi:ro # Mount directory containing the vector database
     environment:
+      - TILED_ENV=${TILED_ENV}
       - DB_PATH=/data/vector_db_smi/latent_vectors.db
       - TILED_API_KEY=${REMOTE_TILED_SINGLE_USER_API_KEY}
       - TILED_LIVE_API_KEY=${REMOTE_TILED_SINGLE_USER_API_KEY}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -125,6 +125,7 @@ services:
       # Tiled
       DEFAULT_TILED_URI: '${DEFAULT_TILED_URI}'
       DATA_TILED_KEY: '${DATA_TILED_KEY}'
+      REMOTE_DATA_TILED_KEY: '${REMOTE_DATA_TILED_KEY}'
       RESULTS_TILED_URI: '${RESULTS_TILED_URI}'
       RESULTS_TILED_API_KEY: '${RESULTS_TILED_API_KEY}'
       # Prefect
@@ -204,6 +205,17 @@ services:
       MLFLOW_CACHE_DIR: "/mlflow_cache"
       PYTHONUNBUFFERED: 1
       MALLOC_TRIM_THRESHOLD_: 0
+      # MLflow
+      MLFLOW_TRACKING_URI: ${MLFLOW_TRACKING_URI}
+      MLFLOW_TRACKING_USERNAME: ${MLFLOW_TRACKING_USERNAME}
+      MLFLOW_TRACKING_PASSWORD: ${MLFLOW_TRACKING_PASSWORD}
+      MLFLOW_TRACKING_INSECURE_TLS: ${MLFLOW_TRACKING_INSECURE_TLS:-False}
+      # Redis
+      REDIS_HOST: ${REDIS_HOST}
+      REDIS_PORT: ${REDIS_PORT}
+      # Tiled Publisher
+      RESULTS_TILED_URI: '${RESULTS_TILED_URI}'
+      RESULTS_TILED_API_KEY: '${RESULTS_TILED_API_KEY}'
     depends_on:
       - latent-space-explorer
     networks:
@@ -235,9 +247,26 @@ services:
     volumes:
       - ./data/test_sim_data:/data/test_data:ro # Mount test data repository containing TIFF images
     environment:
-      - TILED_LIVE_API_KEY=${TILED_SINGLE_USER_API_KEY}
-      - DATA_TILED_KEY=${DATA_TILED_KEY}
+      - TILED_LIVE_API_KEY=${REMOTE_TILED_SINGLE_USER_API_KEY}
+      - DATA_TILED_KEY=${REMOTE_DATA_TILED_KEY}
       - DYNACONF_TILED_POLLER__PUBLISH_ADDRESS=tcp://0.0.0.0:5000 # Make sure ZMQ publisher address is correctly set
+    networks:
+      mle_net:
+
+  # Simulator 3: replay the runs saved in local db during smi beamtime
+  sim_replay:
+    image: ghcr.io/als-computing/arroyosas:main
+    container_name: sim_replay
+    command: python -m arroyosas.app.db_replay_sim_cli
+    profiles:
+      - sim_replay
+    volumes:
+      - ./data/vector_db_smi:/data/vector_db_smi:ro # Mount directory containing the vector database
+    environment:
+      - DB_PATH=/data/vector_db_smi/latent_vectors.db
+      - TILED_API_KEY=${REMOTE_TILED_SINGLE_USER_API_KEY}
+      - TILED_LIVE_API_KEY=${REMOTE_TILED_SINGLE_USER_API_KEY}
+      - DYNACONF_TILED_POLLER__PUBLISH_ADDRESS=tcp://0.0.0.0:5000
     networks:
       mle_net:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -194,6 +194,7 @@ services:
     volumes:
       - .:/app:Z
       - ./data/mlflow_cache:/mlflow_cache
+      - ./data/vector_save:/data/vector_save
     ports:
       - 127.0.0.1:8765:8765
     environment:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ dev = [
     "isort==5.13.2",
     "pre-commit==3.6.2",
     "pytest==8.1.1",
+    "pytest-asyncio"
 ]
 
 simulator = [
@@ -60,6 +61,7 @@ simulator = [
 ]
 
 arroyo = [
+    "aiosqlite",
     "arroyopy<=1.0.0",
     "arroyosas @ git+https://github.com/als-computing/arroyosas.git@move_lse",
     "dynaconf",

--- a/settings.yaml
+++ b/settings.yaml
@@ -9,6 +9,8 @@ lse_operator:
     port: 8765
   listener:
     zmq_address: tcp://sim_realistic:5000
+  vector_save:
+    db_path: /data/vector_save/latent_vectors.db  # Path to SQLite database for saving vectors
 
 lse_reducer:
   demo_mode: true

--- a/settings.yaml
+++ b/settings.yaml
@@ -8,9 +8,12 @@ lse_operator:
     host: 0.0.0.0
     port: 8765
   listener:
-    zmq_address: tcp://sim_realistic:5000
+    zmq_address: tcp://sim_replay:5000
   vector_save:
     db_path: /data/vector_save/latent_vectors.db  # Path to SQLite database for saving vectors
+  tiled_publisher:  # Added new section for TiledResultsPublisher
+    root_segments:
+      - lse_live_results
 
 lse_reducer:
   demo_mode: true

--- a/src/app_layout.py
+++ b/src/app_layout.py
@@ -22,6 +22,11 @@ WRITE_DIR = os.getenv("WRITE_DIR")
 DATA_TILED_KEY = os.getenv("DATA_TILED_KEY", None)
 if DATA_TILED_KEY == "":
     DATA_TILED_KEY = None
+
+REMOTE_DATA_TILED_KEY = os.getenv("REMOTE_DATA_TILED_KEY", None)
+if REMOTE_DATA_TILED_KEY == "":
+    REMOTE_DATA_TILED_KEY = None
+    
 MODE = os.getenv("MODE", "dev")
 PREFECT_TAGS = json.loads(os.getenv("PREFECT_TAGS", '["latent-space-explorer"]'))
 USER = os.getenv("USER")

--- a/src/arroyo_reduction/app.py
+++ b/src/arroyo_reduction/app.py
@@ -48,7 +48,7 @@ async def start() -> None:
         
         # Initialize the WebSocket publisher first (so it's available for connections)
         ws_publisher = LSEWSResultPublisher.from_settings(app_settings.ws_publisher)
-    
+        asyncio.create_task(ws_publisher.start())
 
         # Initialize the VectorSavePublisher for saving vectors to SQLite
         vector_save_publisher = VectorSavePublisher(db_path=app_settings.vector_save.db_path)

--- a/src/arroyo_reduction/app.py
+++ b/src/arroyo_reduction/app.py
@@ -11,6 +11,7 @@ from .operator import LatentSpaceOperator
 from .publisher import LSEWSResultPublisher
 from .redis_model_store import RedisModelStore
 from .vector_save import VectorSavePublisher
+from .tiled_results_publisher import TiledResultsPublisher  # Add import
 
 settings = Dynaconf(
     envvar_prefix="",
@@ -53,7 +54,10 @@ async def start() -> None:
         # Initialize the VectorSavePublisher for saving vectors to SQLite
         vector_save_publisher = VectorSavePublisher(db_path=app_settings.vector_save.db_path)
         asyncio.create_task(vector_save_publisher.start())
-
+        
+        # Initialize the TiledResultsPublisher for saving vectors to Tiled
+        tiled_publisher = TiledResultsPublisher.from_settings(app_settings.tiled_publisher)
+        asyncio.create_task(tiled_publisher.start())
         
         # Initialize Redis model store instead of direct Redis client
         logger.info("Initializing Redis Model Store")
@@ -87,6 +91,7 @@ async def start() -> None:
         operator = LatentSpaceOperator.from_settings(app_settings, settings.lse_reducer)
         operator.add_publisher(ws_publisher)
         operator.add_publisher(vector_save_publisher)
+        operator.add_publisher(tiled_publisher)  # Add the Tiled publisher
         
         listener = ZMQFrameListener.from_settings(app_settings.listener, operator)
         

--- a/src/arroyo_reduction/schemas.py
+++ b/src/arroyo_reduction/schemas.py
@@ -38,3 +38,7 @@ class LatentSpaceEvent(Event):
     index: int
     autoencoder_model: str = None  # Add autoencoder model name
     dimred_model: str = None       # Add dimension reduction model name
+    timestamp: float = None        # Add timestamp for when processing began
+    total_processing_time: float = None  # Total time to process the frame
+    autoencoder_time: float = None  # Time spent in autoencoder processing
+    dimred_time: float = None      # Time spent in dimension reduction processing

--- a/src/arroyo_reduction/tiled_results_publisher.py
+++ b/src/arroyo_reduction/tiled_results_publisher.py
@@ -1,0 +1,261 @@
+import asyncio
+import logging
+import os
+import re
+import time
+from datetime import datetime
+
+import numpy as np
+import pandas as pd
+import pytz  # Added import for timezone
+from arroyopy.publisher import Publisher
+from tiled.client import from_uri
+
+from .schemas import LatentSpaceEvent
+
+logger = logging.getLogger("arroyo_reduction.tiled_results_publisher")
+
+# Environment variables for Tiled connections
+RESULTS_TILED_URI = os.getenv("RESULTS_TILED_URI", "http://tiled:8000")
+RESULTS_TILED_API_KEY = os.getenv("RESULTS_TILED_API_KEY", "")
+
+class TiledResultsPublisher(Publisher):
+    """Publisher that saves latent space vectors to a Tiled server."""
+
+    def __init__(self, tiled_uri=None, tiled_api_key=None, root_segments=None):
+        super().__init__()
+        self.tiled_uri = tiled_uri or RESULTS_TILED_URI
+        self.tiled_api_key = tiled_api_key or RESULTS_TILED_API_KEY
+        self.root_segments = root_segments or ["lse_live_results"]
+        self.client = None
+        self.root_container = None
+        self.daily_container = None
+        
+        # Dictionary to store DataFrames by UUID
+        self.uuid_dataframes = {}
+        # Set to track UUIDs that already exist in Tiled
+        self.existing_uuids = set()
+        # Default table name if no UUID is available
+        self.default_table_name = "feature_vectors"
+        # Keep track of the current UUID
+        self.current_uuid = None
+        
+        # Create a daily run ID using California timezone
+        california_tz = pytz.timezone('US/Pacific')  # Added for California timezone
+        today = datetime.now(california_tz).strftime("%Y-%m-%d")  # Modified to use California timezone
+        self.run_id = f"daily_run_{today}"
+        
+        # Regex pattern to extract UUID from tiled_url
+        self.uuid_pattern = r"([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})"
+        
+        logger.info(f"Initialized publisher with UUID-based table grouping")
+
+    async def start(self):
+        """Connect to Tiled server and initialize containers."""
+        try:
+            self.client = from_uri(self.tiled_uri, api_key=self.tiled_api_key)
+            
+            # Navigate to the root container and create the daily run container inside it
+            await self._setup_containers()
+            
+            # List all existing tables in the daily container
+            if self.daily_container is not None:
+                table_keys = list(self.daily_container)
+                logger.info(f"Found {len(table_keys)} existing tables in daily container")
+                
+                # Add all existing tables to our set of existing UUIDs
+                self.existing_uuids.update(table_keys)
+                logger.info(f"Tracking {len(self.existing_uuids)} existing UUIDs")
+                
+                # Log some examples of existing UUIDs for debugging
+                if self.existing_uuids:
+                    examples = list(self.existing_uuids)[:3]
+                    logger.info(f"Examples of existing UUIDs: {', '.join(examples)}")
+            
+            logger.info(f"Connected to Tiled server at {self.tiled_uri}")
+            logger.info(f"Using container path: {'/'.join(self.root_segments)}/{self.run_id}")
+        except Exception as e:
+            logger.error(f"Failed to initialize Tiled client: {e}")
+            import traceback
+            logger.error(traceback.format_exc())
+    
+    def _extract_uuid_from_url(self, url):
+        """Extract UUID from tiled_url."""
+        if not url:
+            return self.default_table_name
+        
+        # Log the URL for debugging
+        logger.debug(f"Extracting UUID from URL: {url}")
+        
+        match = re.search(self.uuid_pattern, url)
+        if match:
+            uuid = match.group(1)
+            logger.debug(f"Extracted UUID: {uuid}")
+            return uuid
+        
+        logger.debug(f"No UUID found in URL, using default: {self.default_table_name}")
+        return self.default_table_name
+    
+    async def _setup_containers(self):
+        """Set up the container structure."""
+        try:
+            # Navigate through root_segments
+            container = self.client
+            for segment in self.root_segments:
+                if segment not in container:
+                    logger.info(f"Creating container: {segment}")
+                    container = container.create_container(segment)
+                else:
+                    logger.info(f"Using existing container: {segment}")
+                    container = container[segment]
+            
+            # Store reference to the root container
+            self.root_container = container
+            
+            # Now create the daily run container inside the root container
+            if self.run_id not in self.root_container:
+                logger.info(f"Creating daily container: {self.run_id}")
+                self.root_container.create_container(self.run_id)
+            else:
+                logger.info(f"Using existing daily container: {self.run_id}")
+            
+            # Store reference to daily container
+            self.daily_container = self.root_container[self.run_id]
+            
+        except Exception as e:
+            logger.error(f"Error setting up containers: {e}")
+            import traceback
+            logger.error(traceback.format_exc())
+    
+    async def publish(self, message):
+        """Publish a message to Tiled server."""
+        if not isinstance(message, LatentSpaceEvent):
+            return
+
+        try:
+            # Ensure daily container exists
+            if self.daily_container is None:
+                logger.error("Daily container not initialized, cannot publish")
+                return
+
+            # Format vector and metadata
+            vector = np.array(message.feature_vector, dtype=np.float32)
+            if vector.ndim == 1:
+                # Extract UUID from tiled_url
+                tiled_url = getattr(message, "tiled_url", None)
+                uuid = self._extract_uuid_from_url(tiled_url)
+                
+                # Check if this UUID already exists
+                if uuid in self.existing_uuids:
+                    logger.debug(f"Skipping vector for existing UUID: {uuid}")
+                    return
+                
+                # Check if this is a new UUID
+                if self.current_uuid is not None and uuid != self.current_uuid and self.current_uuid in self.uuid_dataframes:
+                    # We have a new UUID, so write the data for the previous UUID (if it's not an existing UUID)
+                    if self.current_uuid not in self.existing_uuids and not self.uuid_dataframes[self.current_uuid].empty:
+                        logger.info(f"New UUID detected, writing data for previous UUID: {self.current_uuid}")
+                        await self._write_table_to_tiled(self.current_uuid)
+                
+                # Update current UUID
+                self.current_uuid = uuid
+                
+                # If this UUID already exists, skip further processing
+                if uuid in self.existing_uuids:
+                    return
+                
+                # Initialize tracking for this UUID if needed
+                if uuid not in self.uuid_dataframes:
+                    self.uuid_dataframes[uuid] = pd.DataFrame()
+                
+                # Create a record with metadata and the vector
+                record = {
+                    "tiled_url": tiled_url,
+                    "autoencoder_model": getattr(message, "autoencoder_model", None),
+                    "dimred_model": getattr(message, "dimred_model", None),
+                    "timestamp": getattr(message, "timestamp", time.time()),
+                    "total_processing_time": getattr(message, "total_processing_time", None),
+                    "autoencoder_time": getattr(message, "autoencoder_time", None),
+                    "dimred_time": getattr(message, "dimred_time", None)
+                }
+                
+                # Add vector elements as columns (limit to first 20 to keep it manageable)
+                for i, val in enumerate(vector[:20]):
+                    record[f"feature_{i}"] = float(val)
+                
+                # Append to DataFrame for this UUID
+                new_row = pd.DataFrame([record])
+                self.uuid_dataframes[uuid] = pd.concat([self.uuid_dataframes[uuid], new_row], ignore_index=True)
+                
+                logger.debug(f"Added vector to table '{uuid}'")
+                
+            else:
+                logger.warning(f"Received vector with unexpected dimensions: {vector.shape}")
+                
+        except Exception as e:
+            logger.error(f"Error publishing to Tiled: {e}")
+            import traceback
+            logger.error(traceback.format_exc())
+    
+    async def _write_table_to_tiled(self, table_key):
+        """Write the collected vectors for a specific UUID to Tiled."""
+        try:
+            # Check if this UUID already exists
+            if table_key in self.existing_uuids:
+                logger.info(f"Skipping write for existing UUID: {table_key}")
+                return
+            
+            # Get the DataFrame for this UUID
+            df = self.uuid_dataframes[table_key]
+            
+            # Log DataFrame info for debugging
+            logger.info(f"Writing {len(df)} vectors to new table '{table_key}'")
+            
+            # Check if DataFrame is empty
+            if df.empty:
+                logger.warning(f"DataFrame for {table_key} is empty, nothing to write")
+                return
+            
+            # Simply write the DataFrame to Tiled
+            try:
+                # Use write_dataframe with the UUID as the key
+                await asyncio.to_thread(
+                    self.daily_container.write_dataframe,
+                    df,
+                    key=table_key
+                )
+                
+                logger.info(f"Successfully wrote {len(df)} vectors to '{table_key}'")
+                
+                # Add this UUID to our set of existing UUIDs
+                self.existing_uuids.add(table_key)
+                
+                # Clear the DataFrame for this UUID
+                self.uuid_dataframes[table_key] = pd.DataFrame()
+                
+            except Exception as e:
+                logger.error(f"Error writing DataFrame for {table_key}: {e}")
+                import traceback
+                logger.error(traceback.format_exc())
+                
+        except Exception as e:
+            logger.error(f"Error in _write_table_to_tiled for {table_key}: {e}")
+            import traceback
+            logger.error(traceback.format_exc())
+
+    async def stop(self):
+        """Write any remaining data for new UUIDs before stopping."""
+        logger.info("Publisher stopping, writing any remaining data for new UUIDs")
+        
+        # Write data for all UUIDs that have accumulated data and don't already exist
+        for uuid in list(self.uuid_dataframes.keys()):
+            if uuid not in self.existing_uuids and not self.uuid_dataframes[uuid].empty:
+                logger.info(f"Writing remaining data for new UUID: {uuid}")
+                await self._write_table_to_tiled(uuid)
+        
+        logger.info("Publisher stopped")
+
+    @classmethod
+    def from_settings(cls, settings):
+        """Create a TiledResultsPublisher from settings."""
+        return cls(root_segments=settings.get("root_segments"))

--- a/src/arroyo_reduction/vector_save.py
+++ b/src/arroyo_reduction/vector_save.py
@@ -54,7 +54,8 @@ class VectorSavePublisher(Publisher):
         await self.db.commit()
 
     async def publish(self, message: LatentSpaceEvent) -> None:
-        # Expect message to be a dict with 'vector' and 'image_url'
+        if not isinstance(message, LatentSpaceEvent):
+            return None
 
         tiled_url = message.tiled_url
         feature_vector = message.feature_vector

--- a/src/arroyo_reduction/vector_save.py
+++ b/src/arroyo_reduction/vector_save.py
@@ -19,7 +19,7 @@ class VectorSavePublisher(Publisher):
         self.db_path = db_path
         self._db_initialized = False
         self.db: aiosqlite.Connection = None
-        # Database will be initialized lazily in _init_db()
+        # Database will be initialized lazily in start()
 
 
     async def _init_db(self):

--- a/src/arroyo_reduction/vector_save.py
+++ b/src/arroyo_reduction/vector_save.py
@@ -1,0 +1,59 @@
+
+import asyncio
+
+import aiosqlite
+import os
+
+from arroyo.listener import Listener
+from arroyosas.zmq import ZMQFrameListener
+
+
+class VectorSaveListener(Listener):
+    def __init__(self, db_path="vector_results.db"):
+        super().__init__()
+        self.db_path = db_path
+        self._db_initialized = False
+
+    async def _init_db(self):
+        if not self._db_initialized:
+            async with aiosqlite.connect(self.db_path) as db:
+                await db.execute('''
+                    CREATE TABLE IF NOT EXISTS vectors (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        image_url TEXT NOT NULL,
+                        vector TEXT NOT NULL
+                    )
+                ''')
+                await db.commit()
+            self._db_initialized = True
+
+    async def save_vector(self, image_url, vector):
+        await self._init_db()
+        async with aiosqlite.connect(self.db_path) as db:
+            await db.execute(
+                "INSERT INTO vectors (image_url, vector) VALUES (?, ?)",
+                (image_url, str(vector))
+            )
+            await db.commit()
+
+    async def handle_message(self, message):
+        # Expect message to be a dict with 'vector' and 'image_url'
+        vector = message.get("vector")
+        image_url = message.get("image_url")
+        if vector is not None and image_url is not None:
+            await self.save_vector(image_url, vector)
+            print(f"Saved vector for {image_url}")
+        else:
+            print("Invalid message: missing 'vector' or 'image_url'")
+
+    async def start(self, zmq_settings):
+        listener = ZMQFrameListener.from_settings(zmq_settings, self)
+        await listener.start()
+
+# Example usage:
+# if __name__ == "__main__":
+#     import dynaconf
+#     settings = dynaconf.Dynaconf(settings_files=["settings.yaml"])
+#     zmq_settings = settings.lse_operator.listener
+#     vs = VectorSaveListener()
+#     asyncio.run(vs.start(zmq_settings))

--- a/src/assets/clientside.js
+++ b/src/assets/clientside.js
@@ -170,11 +170,22 @@ window.dash_clientside = Object.assign({}, window.dash_clientside, {
                         const sliceParam = params.get('slice');
 
                         if (sliceParam) {
-                            // Expecting format like "0,0,:,:"
-                            const sliceParts = sliceParam.split(',');
-                            const parsedIndex = parseInt(sliceParts[0], 10);
-                            if (!isNaN(parsedIndex)) {
-                                index = parsedIndex;
+                            // Expecting format like "0,0,:,:" or "0:1,0:1679,0:1475"
+                            const sliceParts = sliceParam.split(','); 
+                            const firstSliceParts = sliceParts[0];
+                            
+                            if (firstSliceParts.includes(':')) {
+                                // New format: extract the first number before the colon (e.g., "0" from "0:1")
+                                const startIndex = parseInt(firstSliceParts.split(':')[0], 10);
+                                if (!isNaN(startIndex)) {
+                                    index = startIndex;
+                                }
+                            } else {
+                                // Old format: directly parse the first part as an integer
+                                const parsedIndex = parseInt(firstSliceParts, 10);
+                                if (!isNaN(parsedIndex)) {
+                                    index = parsedIndex;
+                                }
                             }
                         } else {
                             // No slice param, assume single data point
@@ -287,9 +298,9 @@ window.dash_clientside = Object.assign({}, window.dash_clientside, {
                             "height": "100%",
                             "backgroundColor": "rgba(0, 0, 0, 0.7)",
                             "zIndex": 9998,
-                            "display": "block"
+                            "display": "none"
                         },
-                        true
+                        false
                     ];
                 }
             }

--- a/src/assets/clientside.js
+++ b/src/assets/clientside.js
@@ -194,6 +194,12 @@ window.dash_clientside = Object.assign({}, window.dash_clientside, {
                         }
 
                         log.debug("Root URI:", root_uri, "URI:", uri, "Index:", index);
+                        
+                        // Change root_uri from /api/v1/array/full to /api/v1/metadata
+                        if (root_uri.includes('/api/v1/array/full')) {
+                            root_uri = root_uri.replace('/api/v1/array/full', '/api/v1/metadata');
+                            log.debug("Modified Root URI:", root_uri);
+                        }
 
                         if (index < 0) {
                             log.warn("Received negative index; skipping update");

--- a/src/test/test_reducer.py
+++ b/src/test/test_reducer.py
@@ -51,7 +51,7 @@ class TestReducer:
         # Mock logger to prevent logging issues
         with patch("src.arroyo_reduction.reducer.logger"):
             # Call reduce()
-            result = reducer.reduce(mock_event)
+            result, timing_info = reducer.reduce(mock_event)
 
         # Verify the processing flow
 
@@ -66,6 +66,11 @@ class TestReducer:
         assert result.shape == (1, 2)  # Check expected shape of UMAP coordinates
         # Verify it's actually the same array we created
         np.testing.assert_array_equal(result, umap_coords)
+        
+        # 4. Verify timing info is returned
+        assert isinstance(timing_info, dict)
+        assert 'autoencoder_time' in timing_info
+        assert 'dimred_time' in timing_info
 
     def test_reduce_during_model_loading(self, reducer, mock_event):
         """Test that reduce() returns None when models are loading"""
@@ -76,10 +81,12 @@ class TestReducer:
         # Mock logger to prevent logging issues
         with patch("src.arroyo_reduction.reducer.logger"):
             # Call reduce()
-            result = reducer.reduce(mock_event)
+            result, timing_info = reducer.reduce(mock_event)
 
         # Verify result is None when models are loading
         assert result is None
+        assert isinstance(timing_info, dict)
+        
         # Models should not be called
         reducer.current_torch_model.predict.assert_not_called()
         reducer.current_dim_reduction_model.predict.assert_not_called()

--- a/src/test/test_vector_save.py
+++ b/src/test/test_vector_save.py
@@ -11,6 +11,9 @@ from src.arroyo_reduction.vector_save import VectorSavePublisher
 async def test_vector_save_listener(tmp_path):
     db_path = tmp_path / "test_vectors.db"
     publisher = VectorSavePublisher(db_path=str(db_path))
+    
+    # Initialize the database but don't call start() which would create a server
+    await publisher._init_db()
 
     # Simulate a message
     message = {
@@ -21,6 +24,8 @@ async def test_vector_save_listener(tmp_path):
         "dimred_model": "model_v2"
     }
     message = LatentSpaceEvent(**message)
+    
+    # Call the publish method directly
     await publisher.publish(message)
 
     # Check that the data was saved
@@ -32,6 +37,10 @@ async def test_vector_save_listener(tmp_path):
             assert rows[0][1] == json.dumps(message.feature_vector)
             assert rows[0][2] == message.autoencoder_model
             assert rows[0][3] == message.dimred_model
+
+    # Explicitly close the database connection
+    if publisher.db is not None:
+        await publisher.db.close()
     
 
 

--- a/src/test/test_vector_save.py
+++ b/src/test/test_vector_save.py
@@ -1,0 +1,35 @@
+import aiosqlite
+import pytest
+import numpy as np
+
+from src.arroyo_reduction.vector_save import VectorSavePublisher
+
+
+@pytest.mark.asyncio
+async def test_vector_save_listener(tmp_path):
+    db_path = tmp_path / "test_vectors.db"
+    publisher = VectorSavePublisher(db_path=str(db_path))
+
+    # Simulate a message
+    message = {"image_url": "http://example.com/image1.jpg", "vector": np.array([1, 2, 3, 4])}
+    await publisher.publish(message)
+
+    # Check that the data was saved
+    async with aiosqlite.connect(str(db_path)) as db:
+        async with db.execute("SELECT image_url, vector FROM vectors") as cursor:
+            rows = await cursor.fetchall()
+            assert len(rows) == 1
+            assert rows[0][0] == message["image_url"]
+            # Convert the stored string back to a numpy array for comparison
+            stored_vector = np.fromstring(rows[0][1][1:-1], sep=',', dtype=int)
+            assert np.array_equal(stored_vector, message["vector"])
+
+    # Test missing fields
+    bad_message = {"image_url": "http://example.com/image2.jpg"}
+    await publisher.publish(bad_message)  # Should not raise
+
+    # Should still only be one row
+    async with aiosqlite.connect(str(db_path)) as db:
+        async with db.execute("SELECT COUNT(*) FROM vectors") as cursor:
+            count = (await cursor.fetchone())[0]
+            assert count == 1

--- a/src/test/test_vector_save.py
+++ b/src/test/test_vector_save.py
@@ -1,5 +1,6 @@
 import aiosqlite
 import json
+import time
 import pytest
 
 
@@ -15,37 +16,51 @@ async def test_vector_save_listener(tmp_path):
     # Initialize the database but don't call start() which would create a server
     await publisher._init_db()
 
-    # Simulate a message
+    # Current timestamp for testing
+    current_time = time.time()
+    
+    # Simulate a message with timing data
     message = {
         "tiled_url": "http://example.com/image1.jpg",
         "feature_vector": [1, 2],
         "index": 0,
         "autoencoder_model": "model_v1",
-        "dimred_model": "model_v2"
+        "dimred_model": "model_v2",
+        "timestamp": current_time,
+        "total_processing_time": 0.1234,
+        "autoencoder_time": 0.0789,
+        "dimred_time": 0.0445
     }
     message = LatentSpaceEvent(**message)
     
     # Call the publish method directly
     await publisher.publish(message)
 
-    # Check that the data was saved
+    # Check that the data was saved, including timing fields
     async with aiosqlite.connect(str(db_path)) as db:
-        async with db.execute("SELECT tiled_url, feature_vector, autoencoder_model, dimred_model FROM vectors") as cursor:
+        async with db.execute("""
+            SELECT 
+                tiled_url, 
+                feature_vector, 
+                autoencoder_model, 
+                dimred_model,
+                timestamp,
+                total_processing_time,
+                autoencoder_time,
+                dimred_time
+            FROM vectors
+        """) as cursor:
             rows = await cursor.fetchall()
             assert len(rows) == 1
             assert rows[0][0] == message.tiled_url
             assert rows[0][1] == json.dumps(message.feature_vector)
             assert rows[0][2] == message.autoencoder_model
             assert rows[0][3] == message.dimred_model
+            assert rows[0][4] == current_time
+            assert rows[0][5] == 0.1234
+            assert rows[0][6] == 0.0789
+            assert rows[0][7] == 0.0445
 
     # Explicitly close the database connection
     if publisher.db is not None:
         await publisher.db.close()
-    
-
-
-    # # Should still only be one row
-    # async with aiosqlite.connect(str(db_path)) as db:
-    #     async with db.execute("SELECT COUNT(*) FROM vectors") as cursor:
-    #         count = (await cursor.fetchone())[0]
-    #         assert count == 1


### PR DESCRIPTION
Edited
This PR introduces changes to the arroyo pieces of the latent space explorer.
1. A publisher that saves 2d vector output to a local sqlite database. We wanted to be able to capture this quickly. Should it go into Tiled instead? I can see plusses and minuses. Putting it into our own database allows for more targetted indexing and querying, which doesn't matter right now but...I would really love to also add timing for the two processing steps as columns in the table so we can see this over time. I don't  know if that kind of thing would ever be searchable in tiled. 
2. Changes to `pyproject.toml` to add asycnio unit tests
3. Unit tests for this new publisher
4. Slightly unrelated, this PR also includes changes to clientside.js that we needed to get live processing done on the types of links that the tiled websocket creates.