### PR TITLE
Xiaoya add xps

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,5 @@
 TILED_SINGLE_USER_API_KEY=<unique api key>
 TILED_ENV="prod" #use dev or prod
-REMOTE_TILED_SINGLE_USER_API_KEY=<unique api key>
 
 PREFECT_DB_PW=<unique password>
 PREFECT_DB_USER=prefect_user
@@ -24,9 +23,9 @@ WRITE_DIR=/path/to/write/results
 DEFAULT_TILED_URI=http://tiled:8000
 DEFAULT_TILED_SUB_URI=
 DATA_TILED_KEY=<your_data_tiled_key>
-REMOTE_DATA_TILED_KEY=<remote_data_tiled_key>
 RESULTS_TILED_URI=http://tiled:8000
 RESULTS_TILED_API_KEY=<your_results_tiled_key>
+LIVE_TILED_API_KEY=<your_live_tiled_key>
 
 # Prefect
 PREFECT_API_URL=http://prefect:4200/api

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 TILED_SINGLE_USER_API_KEY=<unique api key>
 TILED_ENV="prod" #use dev or prod
+SIM_MODE="direct" #use direct, db_replay or local_tiled
 
 PREFECT_DB_PW=<unique password>
 PREFECT_DB_USER=prefect_user

--- a/.github/workflows/publish_docker.yml
+++ b/.github/workflows/publish_docker.yml
@@ -65,3 +65,37 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Extract metadata for Arroyo image
+        id: meta-arroyo
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            suffix=-arroyo,onlatest=true
+
+      - name: Build and push Arroyo Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          file: Dockerfile_arroyo
+          push: true
+          tags: ${{ steps.meta-arroyo.outputs.tags }}
+          labels: ${{ steps.meta-arroyo.outputs.labels }}
+
+      - name: Extract metadata for XPS image
+        id: meta-xps
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            suffix=-arroyo-xps,onlatest=true
+
+      - name: Build and push XPS Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          file: Dockerfile_arroyo_xps
+          push: true
+          tags: ${{ steps.meta-xps.outputs.tags }}
+          labels: ${{ steps.meta-xps.outputs.labels }}

--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,7 @@ results/
 data/
 .DS_Store
 models/
-TRS_test/
+mlflow_local_test/
 
 # mlflow auth details
 basic_auth.ini

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ results/
 data/
 .DS_Store
 models/
+TRS_test/
 
 # mlflow auth details
 basic_auth.ini

--- a/Dockerfile_arroyo_xps
+++ b/Dockerfile_arroyo_xps
@@ -1,0 +1,13 @@
+FROM python:3.11
+
+WORKDIR /app
+
+COPY . /app
+
+RUN pip install --upgrade pip
+RUN pip install .[arroyo]
+
+ENV HOME /app
+
+# Use app_xps.py for XPS data processing
+CMD ["python", "-m", "src.arroyo_reduction.app_xps"]

--- a/README.md
+++ b/README.md
@@ -123,39 +123,59 @@ docker compose --profile arroyo --profile sim up
 ```
 Note for Simulators:
 
-There are four available simulators:
+There are two main types of simulators available:
 
 (1) **Feature Vector Simulator**
    - Does not require Arroyo.
    - Run with:
-     ```bash
-     docker compose --profile vector_sim up
-     ```
+        ```bash
+        docker compose --profile vector_sim up
+        ```
 
-(2) **Public Tiled Dataset Simulator**
-   - Reads images from a public Tiled dataset and sends them to Arroyo.
+(2) **Real Image Simulator**
+   - Requires Arroyo and offers three modes
    - Run with:
-     ```bash
-     docker compose --profile arroyo --profile sim up
-     ```
+        ```bash
+        docker compose --profile sim up
+        ```
 
-(3) **Previous Experiment Simulator**
-   - Reads Tiled URLs stored in a local `.db` from a previous experiment.
-   - Re-reads those images and sends them to Arroyo.
-      ```bash
-      docker compose --profile arroyo --profile sim_replay up
-      ```
+      **Mode 1: Public Tiled Dataset Simulator**
+        - Reads images from a public Tiled dataset and sends them to Arroyo.
+        - In .env, set:
+          ```
+          SIM_MODE="direct" 
+          LIVE_TILED_API_KEY=
+          ```
 
-(4) **Local Tiled Simulator**
-   - Requires you to first start a local Tiled instance and ingest data.
-   - Steps:
-     ```bash
-     docker compose up tiled tiled_db
-     docker compose --profile ingest_images up --no-deps ingest_local_images
-     docker compose --profile arroyo --profile sim_local_tiled up
-     ```
+      **Mode 2: Previous SMI Experiment Simulator**
+        - Reads Tiled URLs stored in a local `.db` file from a previous SMI experiment.
+        - Generating an NSLS-II Tiled API Key (A BNL account and DUO authentication are required):
+          ```python
+          from tiled.client import from_uri
 
-   - When using this simulator, update `lse_operator.operator.zmq_address` in `settings.yaml` accordingly (e.g., `tcp://sim_local_tiled:5000` for the 4th simulator).
+          c = from_uri("https://tiled-dev.nsls2.bnl.gov")
+          # You will be prompted for your password
+          # Then your DUO app will ping you
+          c.context.create_api_key()
+          ```
+        - In .env, set:
+            ```
+            SIM_MODE="db_replay" 
+            LIVE_TILED_API_KEY=<nsls-ii-tiled-key>
+            ```
+
+      **Mode 3: Local Tiled Simulator**
+        - Requires starting a local Tiled instance and ingesting data first.
+        - Start local Tiled instance and ingest data:
+            ```bash
+            docker compose up tiled tiled_db
+            docker compose --profile ingest_images up --no-deps ingest_local_images
+            ```
+        - In .env, set:
+            ```
+            SIM_MODE="local_tiled" 
+            LIVE_TILED_API_KEY=<local-tiled-key>
+            ```
 
 
 4. Register models with MLflow:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -189,6 +189,7 @@ services:
   # To run real image simulator, use
   # docker compose --profile arroyo --profile sim up
 
+  # Original SAXS arroyo service
   arroyo:
     build:
       context: .
@@ -222,6 +223,46 @@ services:
       RESULTS_TILED_API_KEY: '${RESULTS_TILED_API_KEY}'
       # User info
       USER: ${USER}
+    depends_on:
+      - latent-space-explorer
+    networks:
+      mle_net:
+
+  # NEW: XPS arroyo service (XPS_WEBSOCKET_URL environment variable REMOVED)
+  arroyo_xps:
+    build:
+      context: .
+      dockerfile: Dockerfile_arroyo_xps
+    container_name: arroyo_xps
+    profiles:
+      - arroyo_xps
+    volumes:
+      - .:/app:Z
+      - ./data/mlflow_cache:/mlflow_cache
+      - ./data/vector_save:/data/vector_save
+    ports:
+      - 127.0.0.1:8766:8765  # Different external port to avoid conflicts
+    environment:
+      NUMBA_DISABLE_JIT: ${NUMBA_DISABLE_JIT:-0}
+      NUMBA_CPU_NAME: ${NUMBA_CPU_NAME:-generic}
+      NUMBA_CPU_FEATURES: ${NUMBA_CPU_FEATURES:-+neon}
+      MLFLOW_CACHE_DIR: "/mlflow_cache"
+      PYTHONUNBUFFERED: 1
+      MALLOC_TRIM_THRESHOLD_: 0
+      # MLflow
+      MLFLOW_TRACKING_URI: ${MLFLOW_TRACKING_URI}
+      MLFLOW_TRACKING_USERNAME: ${MLFLOW_TRACKING_USERNAME}
+      MLFLOW_TRACKING_PASSWORD: ${MLFLOW_TRACKING_PASSWORD}
+      MLFLOW_TRACKING_INSECURE_TLS: ${MLFLOW_TRACKING_INSECURE_TLS:-False}
+      # Redis
+      REDIS_HOST: ${REDIS_HOST}
+      REDIS_PORT: ${REDIS_PORT}
+      # Tiled Publisher
+      RESULTS_TILED_URI: '${RESULTS_TILED_URI}'
+      RESULTS_TILED_API_KEY: '${RESULTS_TILED_API_KEY}'
+      # User info
+      USER: ${USER}
+      # XPS_WEBSOCKET_URL removed - now configured in settings.yaml
     depends_on:
       - latent-space-explorer
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -339,8 +339,8 @@ services:
       --host 0.0.0.0
       --port 8001
       --data-file /data/shot_averages/combined_all_bin_averages.npy
-      --cycles 100
-      --pause 0.1
+      --cycles 1
+      --pause 1
     profiles:
       - sim_xps
     volumes:
@@ -349,6 +349,8 @@ services:
       - 127.0.0.1:8001:8001
     environment:
       - PYTHONUNBUFFERED=1
+      - WEBSOCKET_PING_TIMEOUT=60  # Add this (default is ~20s)
+      - WEBSOCKET_PING_INTERVAL=20  # Add this (default is ~5s)
     networks:
       mle_net:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -330,6 +330,28 @@ services:
     networks:
       mle_net:
 
+  # XPS WebSocket Simulator - for testing XPS data processing
+  sim_xps:
+    image: ghcr.io/als-computing/arroyosas:main
+    container_name: sim_xps
+    command: >
+      python -m arroyosas.app.xps_websocket_simulator
+      --host 0.0.0.0
+      --port 8001
+      --data-file /data/shot_averages/combined_all_bin_averages.npy
+      --cycles 100
+      --pause 0.1
+    profiles:
+      - sim_xps
+    volumes:
+      - ./data/shot_averages:/data/shot_averages:ro
+    ports:
+      - 127.0.0.1:8001:8001
+    environment:
+      - PYTHONUNBUFFERED=1
+    networks:
+      mle_net:
+
 networks:
   mle_net:
     name: mle_net

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -241,53 +241,29 @@ services:
     networks:
       mle_net:
 
-  # Simulator 2: real image simulator service
-  sim_realistic:
+  # Simulator 2: Unified real image simulator
+  sim_unified:
     image: ghcr.io/als-computing/arroyosas:main
-    container_name: sim_realistic
-    command: python -m arroyosas.app.real_image_sim_cli
+    container_name: sim_unified
+    command: >
+      python -m arroyosas.app.unified_sim_cli
+      --mode ${SIM_MODE:-direct}
     profiles:
       - sim
     volumes:
-      - ./data/test_sim_data:/data/test_data:ro # Mount test data repository containing TIFF images
+      - ./data:/data:rw
     environment:
-      - TILED_LIVE_API_KEY=${LIVE_TILED_API_KEY}
-      - DATA_TILED_KEY=${LIVE_TILED_API_KEY}
-      - DYNACONF_TILED_POLLER__PUBLISH_ADDRESS=tcp://0.0.0.0:5000 # Make sure ZMQ publisher address is correctly set
-    networks:
-      mle_net:
-
-  # Simulator 3: replay the runs saved in local db during smi beamtime
-  sim_replay:
-    image: ghcr.io/als-computing/arroyosas:main
-    container_name: sim_replay
-    command: python -m arroyosas.app.db_replay_sim_cli
-    profiles:
-      - sim_replay
-    volumes:
-      - ./data/vector_db_replay:/data/vector_db_replay:ro # Mount directory containing the vector database
-    environment:
-      - TILED_ENV=${TILED_ENV}
-      - DB_PATH=/data/vector_db_replay/latent_vectors.db
-      - TILED_API_KEY=${LIVE_TILED_API_KEY}
-      - TILED_LIVE_API_KEY=${LIVE_TILED_API_KEY}
+      # SIM_MODE: use direct, db_replay or local_tiled
+      - SIM_MODE=${SIM_MODE:-direct} 
+      # API key
+      - TILED_LIVE_API_KEY=${LIVE_TILED_API_KEY} #TILED_LIVE_API_KEY is required by DynaconfFormat
+      # db_replay mode
+      - DB_PATH=${DB_PATH:-/data/vector_db_replay/latent_vectors.db}
+      - TILED_ENV=${TILED_ENV:-dev}
+      # local_tiled mode
+      - URL_FILE=${URL_FILE:-/data/tiled_url/Nafion_p25_30_run_1.json}
+      # ZMQ
       - DYNACONF_TILED_POLLER__PUBLISH_ADDRESS=tcp://0.0.0.0:5000
-    networks:
-      mle_net:
-
-  # Simulator 4: Read images from Tiled using a saved URL and send via ZMQ
-  sim_local_tiled:
-    image: ghcr.io/als-computing/arroyosas:main
-    container_name: sim_local_tiled
-    command: python -m arroyosas.app.local_tiled_sim_cli
-    profiles:
-      - sim_local_tiled
-    volumes:
-      - ./data:/data:rw  # Mount directory for the URL file
-    environment:
-      - URL_FILE=/data/tiled_url/Nafion_p25_30_run_1.json
-      - TILED_API_KEY=${TILED_SINGLE_USER_API_KEY}
-      - TILED_LIVE_API_KEY=${TILED_SINGLE_USER_API_KEY}
       - DYNACONF_TILED_POLLER__ZMQ_FRAME_PUBLISHER__ADDRESS=tcp://0.0.0.0:5000
     networks:
       mle_net:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -220,6 +220,8 @@ services:
       # Tiled Publisher
       RESULTS_TILED_URI: '${RESULTS_TILED_URI}'
       RESULTS_TILED_API_KEY: '${RESULTS_TILED_API_KEY}'
+      # User info
+      USER: ${USER}
     depends_on:
       - latent-space-explorer
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -241,7 +241,7 @@ services:
       - ./data/mlflow_cache:/mlflow_cache
       - ./data/vector_save:/data/vector_save
     ports:
-      - 127.0.0.1:8766:8765  # Different external port to avoid conflicts
+      - 127.0.0.1:8765:8765  
     environment:
       NUMBA_DISABLE_JIT: ${NUMBA_DISABLE_JIT:-0}
       NUMBA_CPU_NAME: ${NUMBA_CPU_NAME:-generic}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -128,7 +128,7 @@ services:
       # Tiled
       DEFAULT_TILED_URI: '${DEFAULT_TILED_URI}'
       DATA_TILED_KEY: '${DATA_TILED_KEY}'
-      REMOTE_DATA_TILED_KEY: '${REMOTE_DATA_TILED_KEY}'
+      LIVE_TILED_API_KEY: '${LIVE_TILED_API_KEY}'
       RESULTS_TILED_URI: '${RESULTS_TILED_URI}'
       RESULTS_TILED_API_KEY: '${RESULTS_TILED_API_KEY}'
       # Prefect
@@ -251,8 +251,8 @@ services:
     volumes:
       - ./data/test_sim_data:/data/test_data:ro # Mount test data repository containing TIFF images
     environment:
-      - TILED_LIVE_API_KEY=${REMOTE_TILED_SINGLE_USER_API_KEY}
-      - DATA_TILED_KEY=${REMOTE_DATA_TILED_KEY}
+      - TILED_LIVE_API_KEY=${LIVE_TILED_API_KEY}
+      - DATA_TILED_KEY=${LIVE_TILED_API_KEY}
       - DYNACONF_TILED_POLLER__PUBLISH_ADDRESS=tcp://0.0.0.0:5000 # Make sure ZMQ publisher address is correctly set
     networks:
       mle_net:
@@ -265,12 +265,12 @@ services:
     profiles:
       - sim_replay
     volumes:
-      - ./data/vector_db_smi:/data/vector_db_smi:ro # Mount directory containing the vector database
+      - ./data/vector_db_replay:/data/vector_db_replay:ro # Mount directory containing the vector database
     environment:
       - TILED_ENV=${TILED_ENV}
-      - DB_PATH=/data/vector_db_smi/latent_vectors.db
-      - TILED_API_KEY=${REMOTE_TILED_SINGLE_USER_API_KEY}
-      - TILED_LIVE_API_KEY=${REMOTE_TILED_SINGLE_USER_API_KEY}
+      - DB_PATH=/data/vector_db_replay/latent_vectors.db
+      - TILED_API_KEY=${LIVE_TILED_API_KEY}
+      - TILED_LIVE_API_KEY=${LIVE_TILED_API_KEY}
       - DYNACONF_TILED_POLLER__PUBLISH_ADDRESS=tcp://0.0.0.0:5000
     networks:
       mle_net:

--- a/frontend.py
+++ b/frontend.py
@@ -68,7 +68,7 @@ from src.callbacks.experiment_replay import (  # noqa: F401
     load_experiment_uuids,
     toggle_load_button,
     load_experiment_replay,
-    filter_experiment_by_percentage,
+    filter_experiment_by_range,
 )
 
 load_dotenv(".env")

--- a/frontend.py
+++ b/frontend.py
@@ -67,6 +67,7 @@ from src.callbacks.live_mode import (  # noqa: F401
 from src.callbacks.experiment_replay import (  # noqa: F401
     load_experiment_uuids,
     toggle_load_button,
+    load_experiment_replay,
 )
 
 load_dotenv(".env")

--- a/frontend.py
+++ b/frontend.py
@@ -68,6 +68,7 @@ from src.callbacks.experiment_replay import (  # noqa: F401
     load_experiment_uuids,
     toggle_load_button,
     load_experiment_replay,
+    filter_experiment_by_percentage,
 )
 
 load_dotenv(".env")

--- a/frontend.py
+++ b/frontend.py
@@ -1,6 +1,30 @@
 import json
 import os
+import sys
 from uuid import uuid4
+
+# Configure logging at the earliest possible point
+import logging
+import sys
+
+# Set up basic configuration
+logging.basicConfig(
+    level=logging.INFO,  # Use DEBUG to see all logs
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+    handlers=[logging.StreamHandler(sys.stdout)]
+)
+
+# Create logger for this module
+logger = logging.getLogger("lse")
+logger.info("Logging configured. Frontend module initializing.")
+
+# Explicitly set level for lse namespace
+logging.getLogger("lse").setLevel(logging.INFO)
+
+# Force propagation for all existing lse loggers
+for name in logging.root.manager.loggerDict:
+    if name.startswith('lse.'):
+        logging.getLogger(name).propagate = True
 
 from dash import Input, Output, html
 from dotenv import load_dotenv
@@ -38,6 +62,11 @@ from src.callbacks.live_mode import (  # noqa: F401
     toggle_pause_button,
     toggle_pause_button_go_live,
     update_data_project_dict,
+)
+# Add this to the imports at the top
+from src.callbacks.experiment_replay import (  # noqa: F401
+    load_experiment_uuids,
+    toggle_load_button,
 )
 
 load_dotenv(".env")

--- a/live_operator_example/mlflow_config.yaml
+++ b/live_operator_example/mlflow_config.yaml
@@ -1,9 +1,8 @@
 # Common settings
 common:
-  dataset: "trs"  # "smi" or "trs" - determines which dataset config to use
+  dataset: "smi"  # "smi" or "trs" - determines which dataset config to use
   autoencoder_type: "VAE"  # use VIT or VAE
   dimred_type: "joblib" #use joblib or neural
-  dimred_transformation: false  # ADDED: true for [square, robust_scale], false for no_transformation
 
 # Model configurations organized by dataset
 models:
@@ -40,13 +39,9 @@ models:
     dr_neural_model_name: "trs_dr_neural_pca_vae"
     weights_path: "../models/trs_vae/vae_model_128_weights.npz"
     code_path: "../models/vae/vae.py"
-    # Paths for no_transformation models
-    dr_weights_path: "../models/trs_vae/pca_model_no_transformation.joblib"
-    dr_neural_weights_path: "../models/trs_vae/neural_pca_model_no_transformation.pth"
+    dr_weights_path: "../models/trs_vae/pca_model.joblib"
+    dr_neural_weights_path: "../models/trs_vae/neural_pca_model.pth"
     dr_neural_scaler_path: "../models/trs_vae/scaler.pkl"
-    # ✅ ADDED: Paths for transformed models (when dimred_transformation: true)
-    dr_weights_path_transformed: "../models/trs_vae/pca_model_square_robust_scale.joblib"
-    dr_neural_weights_path_transformed: "../models/trs_vae/neural_pca_model_square_robust_scale.pth"
     latent_dim: 256
     image_size: [128, 128]
 

--- a/live_operator_example/mlflow_config.yaml
+++ b/live_operator_example/mlflow_config.yaml
@@ -1,8 +1,8 @@
 # Common settings
 common:
-  dataset: "smi"  # "smi" or "trs" - determines which dataset config to use
+  dataset: "trs"  # "smi" or "trs" - determines which dataset config to use
   autoencoder_type: "VAE"  # use VIT or VAE
-  dimred_type: "joblib" #use joblib or neural
+  dimred_type: "neural" #use joblib or neural
 
 # Model configurations organized by dataset
 models:

--- a/live_operator_example/mlflow_config.yaml
+++ b/live_operator_example/mlflow_config.yaml
@@ -1,11 +1,14 @@
 # Common settings
 common:
+  dataset: "trs"  # "smi" or "trs" - determines which dataset config to use
   autoencoder_type: "VAE"  # use VIT or VAE
-  umap_type: "neural" #use joblib or neural
+  dimred_type: "joblib" #use joblib or neural
+  dimred_transformation: false  # ADDED: true for [square, robust_scale], false for no_transformation
 
-# Model configurations
+# Model configurations organized by dataset
 models:
-  vit:
+  # ============= SMI Dataset Models =============
+  smi_vit:
     experiment_name: "smi_exp_vit"
     auto_model_name: "smi_auto_vit"
     dr_model_name: "smi_dr_umap_vit"
@@ -14,8 +17,8 @@ models:
     dr_weights_path: "../models/vit/vit_joblib_test.joblib"
     latent_dim: 64
     image_size: [512, 512]
-  
-  vae:
+    
+  smi_vae:
     experiment_name: "smi_exp_vae"
     auto_model_name: "smi_auto_vae"
     dr_model_name: "smi_dr_umap_vae"
@@ -28,9 +31,26 @@ models:
     latent_dim: 512
     image_size: [512, 512]
 
+  
+  # ============= TRS Dataset Models =============
+  trs_vae:
+    experiment_name: "trs_exp_vae"
+    auto_model_name: "trs_auto_vae"
+    dr_model_name: "trs_dr_pca_vae"
+    dr_neural_model_name: "trs_dr_neural_pca_vae"
+    weights_path: "../models/trs_vae/vae_model_128_weights.npz"
+    code_path: "../models/vae/vae.py"
+    # Paths for no_transformation models
+    dr_weights_path: "../models/trs_vae/pca_model_no_transformation.joblib"
+    dr_neural_weights_path: "../models/trs_vae/neural_pca_model_no_transformation.pth"
+    dr_neural_scaler_path: "../models/trs_vae/scaler.pkl"
+    # ✅ ADDED: Paths for transformed models (when dimred_transformation: true)
+    dr_weights_path_transformed: "../models/trs_vae/pca_model_square_robust_scale.joblib"
+    dr_neural_weights_path_transformed: "../models/trs_vae/neural_pca_model_square_robust_scale.pth"
+    latent_dim: 256
+    image_size: [128, 128]
+
 # Save settings
 save:
   autoencoder: "true"
   dr: "true"
-
-

--- a/live_operator_example/save_mlflow_wrapper.py
+++ b/live_operator_example/save_mlflow_wrapper.py
@@ -19,6 +19,7 @@ from pathlib import Path
 
 # Fix transformers compatibility BEFORE any imports
 os.environ["TRANSFORMERS_USE_TORCH_EXPORT"] = "0"
+os.environ['MLFLOW_ARTIFACT_ROOT'] = os.path.expanduser('~/mlflow_artifacts')
 
 import mlflow
 from dotenv import load_dotenv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "Pillow",
     "plotly>=5.21.0,<6.0.0",
     "plotly-express",
-    "pyFAI==2023.9.0",
+    "pyFAI",
     "python-dotenv",
     "pyarrow>=14.0.1",
     "requests",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "Pillow",
     "plotly>=5.21.0,<6.0.0",
     "plotly-express",
-    "pyFAI",
+    "pyFAI==2025.3.0",
     "python-dotenv",
     "pyarrow>=14.0.1",
     "requests",

--- a/settings.yaml
+++ b/settings.yaml
@@ -9,6 +9,8 @@ lse_operator:
     port: 8765
   listener:
     zmq_address: tcp://sim_unified:5000
+  xps_listener:
+    websocket_url: ws://processor:8001/simImages
   vector_save:
     db_path: /data/vector_save/latent_vectors.db  # Path to SQLite database for saving vectors
   tiled_publisher:  # Added new section for TiledResultsPublisher

--- a/settings.yaml
+++ b/settings.yaml
@@ -10,7 +10,7 @@ lse_operator:
   listener:
     zmq_address: tcp://sim_unified:5000
   xps_listener:
-    websocket_url: ws://processor:8001/simImages
+    websocket_url: ws://sim_xps:8001/simImages
   vector_save:
     db_path: /data/vector_save/latent_vectors.db  # Path to SQLite database for saving vectors
   tiled_publisher:  # Added new section for TiledResultsPublisher

--- a/settings.yaml
+++ b/settings.yaml
@@ -16,6 +16,8 @@ lse_operator:
   tiled_publisher:  # Added new section for TiledResultsPublisher
     root_segments:
       - lse_live_results
+  local_image_publisher:  # New section for TiledLocalImagePublisher
+    container_name: live_data_cache  # Container for storing images
 
 lse_reducer:
   demo_mode: true

--- a/settings.yaml
+++ b/settings.yaml
@@ -8,7 +8,7 @@ lse_operator:
     host: 0.0.0.0
     port: 8765
   listener:
-    zmq_address: tcp://sim_local_tiled:5000
+    zmq_address: tcp://sim_unified:5000
   vector_save:
     db_path: /data/vector_save/latent_vectors.db  # Path to SQLite database for saving vectors
   tiled_publisher:  # Added new section for TiledResultsPublisher

--- a/src/app_layout.py
+++ b/src/app_layout.py
@@ -23,9 +23,9 @@ DATA_TILED_KEY = os.getenv("DATA_TILED_KEY", None)
 if DATA_TILED_KEY == "":
     DATA_TILED_KEY = None
 
-REMOTE_DATA_TILED_KEY = os.getenv("REMOTE_DATA_TILED_KEY", None)
-if REMOTE_DATA_TILED_KEY == "":
-    REMOTE_DATA_TILED_KEY = None
+LIVE_TILED_API_KEY = os.getenv("LIVE_TILED_API_KEY", None)
+if LIVE_TILED_API_KEY == "":
+    LIVE_TILED_API_KEY = None
     
 MODE = os.getenv("MODE", "dev")
 PREFECT_TAGS = json.loads(os.getenv("PREFECT_TAGS", '["latent-space-explorer"]'))

--- a/src/arroyo_reduction/app_xps.py
+++ b/src/arroyo_reduction/app_xps.py
@@ -20,7 +20,7 @@ settings = Dynaconf(
     load_dotenv=True,
 )
 app = typer.Typer()
-logger = logging.getLogger("arroyo_reduction.xps")
+logger = logging.getLogger("arroyo_reduction")
 
 # Redis connection info
 REDIS_HOST = os.getenv("REDIS_HOST", "kvrocks")

--- a/src/arroyo_reduction/app_xps.py
+++ b/src/arroyo_reduction/app_xps.py
@@ -12,6 +12,7 @@ from .redis_model_store import RedisModelStore
 from .vector_save import VectorSavePublisher
 from .tiled_results_publisher import TiledResultsPublisher
 from .xps_websocket_listener import XPSWebSocketListener
+from .xps_tiled_local_image_publisher import XPSTiledLocalImagePublisher  # NEW: Add this import
 
 settings = Dynaconf(
     envvar_prefix="",
@@ -55,6 +56,10 @@ async def start() -> None:
         tiled_publisher = TiledResultsPublisher.from_settings(app_settings.tiled_publisher)
         asyncio.create_task(tiled_publisher.start())
         
+        # NEW: Initialize the XPS-specific local image publisher
+        xps_local_image_publisher = XPSTiledLocalImagePublisher.from_settings(app_settings.local_image_publisher)
+        asyncio.create_task(xps_local_image_publisher.start())
+        
         # Initialize Redis model store instead of direct Redis client
         logger.info("Initializing Redis Model Store")
         redis_model_store = RedisModelStore(host=REDIS_HOST, port=REDIS_PORT)
@@ -88,6 +93,7 @@ async def start() -> None:
         operator.add_publisher(ws_publisher)
         operator.add_publisher(vector_save_publisher)
         operator.add_publisher(tiled_publisher)
+        operator.add_publisher(xps_local_image_publisher)  # NEW: Add this line
         
         # Use from_settings() pattern (consistent with ZMQFrameListener)
         listener = XPSWebSocketListener.from_settings(app_settings.xps_listener, operator)

--- a/src/arroyo_reduction/app_xps.py
+++ b/src/arroyo_reduction/app_xps.py
@@ -1,0 +1,104 @@
+import asyncio
+import logging
+import os
+import sys
+
+import typer
+from dynaconf import Dynaconf
+
+from .operator import LatentSpaceOperator
+from .publisher import LSEWSResultPublisher
+from .redis_model_store import RedisModelStore
+from .vector_save import VectorSavePublisher
+from .tiled_results_publisher import TiledResultsPublisher
+from .xps_websocket_listener import XPSWebSocketListener
+
+settings = Dynaconf(
+    envvar_prefix="",
+    settings_files=["settings.yaml", ".secrets.yaml"],
+    load_dotenv=True,
+)
+app = typer.Typer()
+logger = logging.getLogger("arroyo_reduction.xps")
+
+# Redis connection info
+REDIS_HOST = os.getenv("REDIS_HOST", "kvrocks")
+REDIS_PORT = int(os.getenv("REDIS_PORT", 6666))
+
+def setup_logger(logger: logging.Logger, log_level: str = "INFO"):
+    formatter = logging.Formatter("%(levelname)s: (%(name)s)  %(message)s ")
+    handler = logging.StreamHandler()
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    logger.setLevel(log_level.upper())
+    logger.debug("DEBUG LOGGING SET")
+
+setup_logger(logger, settings.logging_level)
+
+
+@app.command()
+async def start() -> None:
+    try:
+        app_settings = settings.lse_operator
+        logger.info("Starting XPS Latent Space Encoder")
+        logger.info(f"{settings.lse_operator}")
+        
+        # Initialize the WebSocket publisher first (so it's available for connections)
+        ws_publisher = LSEWSResultPublisher.from_settings(app_settings.ws_publisher)
+        asyncio.create_task(ws_publisher.start())
+
+        # Initialize the VectorSavePublisher for saving vectors to SQLite
+        vector_save_publisher = VectorSavePublisher(db_path=app_settings.vector_save.db_path)
+        asyncio.create_task(vector_save_publisher.start())
+        
+        # Initialize the TiledResultsPublisher for saving vectors to Tiled
+        tiled_publisher = TiledResultsPublisher.from_settings(app_settings.tiled_publisher)
+        asyncio.create_task(tiled_publisher.start())
+        
+        # Initialize Redis model store instead of direct Redis client
+        logger.info("Initializing Redis Model Store")
+        redis_model_store = RedisModelStore(host=REDIS_HOST, port=REDIS_PORT)
+        
+        # Wait for model selection in Redis before starting listener
+        logger.info("Waiting for models to be selected in the UI...")
+        
+        # Poll Redis for model selections using the model store
+        while True:
+            try:
+                # Check if both models are selected using the model store
+                autoencoder_model = redis_model_store.get_autoencoder_model()
+                dimred_model = redis_model_store.get_dimred_model()
+                
+                if autoencoder_model and dimred_model:
+                    logger.info(f"Models selected - starting processing:")
+                    logger.info(f"  Autoencoder: {autoencoder_model}")
+                    logger.info(f"  Dimension Reduction: {dimred_model}")
+                    break
+                
+                # Wait before checking again
+                await asyncio.sleep(2)
+                logger.debug("Still waiting for model selection...")
+                
+            except Exception as e:
+                logger.error(f"Error checking Redis: {e}")
+                await asyncio.sleep(5)  # Longer delay on error
+        
+        # Models are selected, now create operator and start listening
+        operator = LatentSpaceOperator.from_settings(app_settings, settings.lse_reducer)
+        operator.add_publisher(ws_publisher)
+        operator.add_publisher(vector_save_publisher)
+        operator.add_publisher(tiled_publisher)
+        
+        # Use from_settings() pattern (consistent with ZMQFrameListener)
+        listener = XPSWebSocketListener.from_settings(app_settings.xps_listener, operator)
+        
+        # Start the listener
+        logger.info("Starting to listen for XPS messages")
+        await listener.start()
+        
+    except Exception as e:
+        logger.critical(f"Fatal error in XPS application: {e}")
+        sys.exit(1)
+
+if __name__ == "__main__":
+    asyncio.run(start())

--- a/src/arroyo_reduction/operator.py
+++ b/src/arroyo_reduction/operator.py
@@ -42,6 +42,7 @@ class LatentSpaceOperator(Operator):
             logger.info("Received Start Message")
             await self.publish(message)
         elif isinstance(message, RawFrameEvent):
+            await self.publish(message)
             result = await self.dispatch(message)
             if result is not None:  # Only publish if we got a valid result
                 await self.publish(result)

--- a/src/arroyo_reduction/operator.py
+++ b/src/arroyo_reduction/operator.py
@@ -88,12 +88,16 @@ class LatentSpaceOperator(Operator):
             current_autoencoder = self.reducer.autoencoder_model_name
             current_dimred = self.reducer.dimred_model_name
             
+            # NEW: Get experiment name from the reducer
+            experiment_name = self.reducer.experiment_name
+            
             response = LatentSpaceEvent(
                 tiled_url=message.tiled_url,
                 feature_vector=feature_vector[0].tolist(),
                 index=message.frame_number,
                 autoencoder_model=current_autoencoder,  # Add autoencoder model name
                 dimred_model=current_dimred,            # Add dimension reduction model name
+                experiment_name=experiment_name,        # NEW: Add experiment name
                 timestamp=start_time,                   # Add start timestamp
                 total_processing_time=total_processing_time,  # Add total processing time
                 autoencoder_time=timing_info.get('autoencoder_time'),  # Add autoencoder processing time

--- a/src/arroyo_reduction/redis_model_store.py
+++ b/src/arroyo_reduction/redis_model_store.py
@@ -20,6 +20,7 @@ class RedisModelStore:
     # Redis Key Constants
     KEY_AUTOENCODER_MODEL = "selected_mlflow_model"
     KEY_DIMRED_MODEL = "selected_dim_reduction_model"
+    KEY_EXPERIMENT_NAME = "experiment_name"  # NEW: Add this constant
     
     # Redis Channel Constants
     CHANNEL_MODEL_UPDATES = "model_updates"
@@ -47,7 +48,48 @@ class RedisModelStore:
         except Exception as e:
             self.redis_client = None
             logger.warning(f"Could not connect to Redis: {e}")
+            
+    # NEW: Add these methods after the existing model methods
+    def store_experiment_name(self, experiment_name: str) -> bool:
+        """
+        Store experiment name in Redis
+        
+        Args:
+            experiment_name: Name of the experiment (can be empty string to clear)
+            
+        Returns:
+            bool: Success status
+        """
+        if self.redis_client is None:
+            logger.warning("Redis client not available")
+            return False
+        
+        try:
+            logger.info(f"Storing experiment name: {experiment_name}")
+            self.redis_client.set(self.KEY_EXPERIMENT_NAME, experiment_name)
+            return True
+        except Exception as e:
+            logger.error(f"Error storing experiment name in Redis: {e}")
+            return False
     
+    def get_experiment_name(self) -> str:
+        """
+        Get experiment name from Redis
+        
+        Returns:
+            str: Experiment name or None if not set
+        """
+        if self.redis_client is None:
+            logger.warning("Redis client not available")
+            return None
+        
+        try:
+            experiment_name = self.redis_client.get(self.KEY_EXPERIMENT_NAME)
+            logger.debug(f"Retrieved experiment name: {experiment_name}")
+            return experiment_name
+        except Exception as e:
+            logger.error(f"Error retrieving experiment name from Redis: {e}")
+            return None
     # =====================================================================
     # Key-Value Store Methods for Model Selection Storage
     # =====================================================================

--- a/src/arroyo_reduction/reducer.py
+++ b/src/arroyo_reduction/reducer.py
@@ -72,7 +72,9 @@ class LatentSpaceReducer(Reducer):
         # Get model selections from Redis (may include version in "name:version" format)
         self.autoencoder_model_name = self.redis_model_store.get_autoencoder_model()
         self.dimred_model_name = self.redis_model_store.get_dimred_model()
+        self.experiment_name = self.redis_model_store.get_experiment_name()
         
+        logger.info(f"Using experiment name: {self.experiment_name}")
         logger.info(f"Using autoencoder model: {self.autoencoder_model_name}")
         logger.info(f"Using dimension reduction model: {self.dimred_model_name}")
         

--- a/src/arroyo_reduction/reducer.py
+++ b/src/arroyo_reduction/reducer.py
@@ -188,8 +188,8 @@ class LatentSpaceReducer(Reducer):
             # Start timing dimension reduction processing
             dimred_start = time.time()
             
-            umap_result = self.current_dim_reduction_model.predict(latent_features)  
-            f_vec = umap_result["umap_coords"]
+            dimred_result = self.current_dim_reduction_model.predict(latent_features)  
+            f_vec = dimred_result["coords"]
             
             # End timing dimension reduction processing
             dimred_end = time.time()

--- a/src/arroyo_reduction/reducer.py
+++ b/src/arroyo_reduction/reducer.py
@@ -247,6 +247,14 @@ class LatentSpaceReducer(Reducer):
     def _handle_model_update(self, update):
         """Handle a model update from Redis PubSub with version support"""
         try:
+            # NEW: Check if this is an experiment name update
+            if update.get("update_type") == "experiment_name":
+                new_experiment_name = update.get("experiment_name")
+                logger.info(f"Received experiment name update: {new_experiment_name}")
+                self.experiment_name = new_experiment_name
+                return
+            
+            # Otherwise handle model updates as before
             model_type = update.get("model_type")
             model_id = update.get("model_name")
             

--- a/src/arroyo_reduction/schemas.py
+++ b/src/arroyo_reduction/schemas.py
@@ -38,6 +38,7 @@ class LatentSpaceEvent(Event):
     index: int
     autoencoder_model: str = None  # Add autoencoder model name
     dimred_model: str = None       # Add dimension reduction model name
+    experiment_name: str = None    # NEW: Add experiment name
     timestamp: float = None        # Add timestamp for when processing began
     total_processing_time: float = None  # Total time to process the frame
     autoencoder_time: float = None  # Time spent in autoencoder processing

--- a/src/arroyo_reduction/vector_save.py
+++ b/src/arroyo_reduction/vector_save.py
@@ -33,6 +33,7 @@ class VectorSavePublisher(Publisher):
                     feature_vector TEXT NOT NULL,
                     autoencoder_model TEXT,
                     dimred_model TEXT,
+                    experiment_name TEXT,
                     timestamp REAL,
                     total_processing_time REAL,
                     autoencoder_time REAL,
@@ -48,6 +49,7 @@ class VectorSavePublisher(Publisher):
             feature_vector: list[float],
             autoencoder_model: str,
             dimred_model: str,
+            experiment_name: str = None,  # Add parameter
             timestamp: float = None,
             total_processing_time: float = None,
             autoencoder_time: float = None,
@@ -57,8 +59,8 @@ class VectorSavePublisher(Publisher):
         vector_str = json.dumps(feature_vector)
 
         await self.db.execute(
-            "INSERT INTO vectors (tiled_url, feature_vector, autoencoder_model, dimred_model, timestamp, total_processing_time, autoencoder_time, dimred_time) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-            (tiled_url, vector_str, autoencoder_model, dimred_model, timestamp, total_processing_time, autoencoder_time, dimred_time)
+            "INSERT INTO vectors (tiled_url, feature_vector, autoencoder_model, dimred_model, experiment_name, timestamp, total_processing_time, autoencoder_time, dimred_time) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (tiled_url, vector_str, autoencoder_model, dimred_model, experiment_name, timestamp, total_processing_time, autoencoder_time, dimred_time)
         )
         await self.db.commit()
 
@@ -70,6 +72,7 @@ class VectorSavePublisher(Publisher):
         feature_vector = message.feature_vector
         autoencoder_model = message.autoencoder_model
         dimred_model = message.dimred_model
+        experiment_name = getattr(message, "experiment_name", None)  # Get experiment name
         timestamp = message.timestamp if hasattr(message, "timestamp") else time.time()
         total_processing_time = message.total_processing_time if hasattr(message, "total_processing_time") else None
         autoencoder_time = message.autoencoder_time if hasattr(message, "autoencoder_time") else None
@@ -80,6 +83,7 @@ class VectorSavePublisher(Publisher):
             feature_vector=feature_vector,
             autoencoder_model=autoencoder_model,
             dimred_model=dimred_model,
+            experiment_name=experiment_name,  # Pass experiment name
             timestamp=timestamp,
             total_processing_time=total_processing_time,
             autoencoder_time=autoencoder_time,

--- a/src/arroyo_reduction/xps_tiled_local_image_publisher.py
+++ b/src/arroyo_reduction/xps_tiled_local_image_publisher.py
@@ -1,0 +1,186 @@
+import asyncio
+import logging
+import os
+from urllib.parse import urlparse
+
+from arroyopy.publisher import Publisher
+from arroyosas.schemas import SASStop, RawFrameEvent
+from tiled.client import from_uri
+
+logger = logging.getLogger("arroyo_reduction.xps_tiled_local_image_publisher")
+
+# API key for Tiled authentication
+LOCAL_TILED_API_KEY = os.getenv("RESULTS_TILED_API_KEY", "")
+
+
+class XPSTiledLocalImagePublisher(Publisher):
+    """Publisher that saves XPS raw images to a local Tiled server directly to the target path."""
+
+    def __init__(self, tiled_api_key=None):
+        super().__init__()
+        self.tiled_api_key = tiled_api_key or LOCAL_TILED_API_KEY
+        self.client = None
+        self.tiled_base_uri = None  # Will be extracted from the first URL
+
+        # Dictionary to track saved images to avoid duplicates
+        self.saved_images = set()
+
+        logger.info(f"Initialized XPSTiledLocalImagePublisher")
+
+    async def start(self):
+        """Initialize - actual connection happens on first publish."""
+        logger.info("XPSTiledLocalImagePublisher ready")
+
+    def _get_client(self, url):
+        """Get or create Tiled client from URL."""
+        if self.client is None:
+            # Extract base URI from the URL
+            parsed_url = urlparse(url)
+            self.tiled_base_uri = f"{parsed_url.scheme}://{parsed_url.netloc}"
+            logger.info(f"Connecting to Tiled server at {self.tiled_base_uri}")
+            self.client = from_uri(self.tiled_base_uri, api_key=self.tiled_api_key)
+        return self.client
+
+    def _extract_path_from_url(self, url):
+        """
+        Extract the storage path from the tiled URL.
+        
+        Input: http://{base_url}/api/v1/array/full/beamlines/bl931/processed/live_data_cache/UUID/xps_averaged_heatmaps/frame_0?slice=...
+        Output: ['beamlines', 'bl931', 'processed', 'live_data_cache', 'UUID', 'xps_averaged_heatmaps', 'frame_0']
+        """
+        try:
+            parsed_url = urlparse(url)
+            path_parts = parsed_url.path.split('/')
+            
+            # Find the position of "array/full" to extract the path after it
+            array_full_idx = -1
+            for i, part in enumerate(path_parts):
+                if part == "array" and i < len(path_parts) - 1 and path_parts[i+1] == "full":
+                    array_full_idx = i + 1
+                    break
+            
+            if array_full_idx >= 0:
+                # Get everything after "array/full"
+                storage_path = path_parts[array_full_idx+1:]
+                # Remove empty strings
+                storage_path = [p for p in storage_path if p]
+                return storage_path
+            
+            return []
+        except Exception as e:
+            logger.error(f"Error extracting path from URL {url}: {e}")
+            return []
+
+    def _save_image_sync(self, image_array, tiled_url):
+        """Save XPS image to Tiled server synchronously using the path from tiled_url."""
+        try:
+            # Get or create client from URL
+            client = self._get_client(tiled_url)
+            
+            if client is None:
+                logger.error("Could not initialize client")
+                return False
+
+            # Extract the full path from the URL
+            path_parts = self._extract_path_from_url(tiled_url)
+            
+            if not path_parts:
+                logger.error(f"Could not extract path from URL: {tiled_url}")
+                return False
+            
+            # Create a unique key for this image to avoid duplicates
+            image_key = '/'.join(path_parts)
+            
+            # Skip if we've already saved this image
+            if image_key in self.saved_images:
+                logger.debug(f"Image already saved: {image_key}")
+                return True
+
+            # Navigate/create the path structure
+            current = client
+            
+            # Navigate through all path components except the last one (which is the array name)
+            for component in path_parts[:-1]:
+                if component not in current:
+                    logger.info(f"Creating container: {component}")
+                    current = current.create_container(component)
+                else:
+                    current = current[component]
+            
+            # Save the image with the last component as the key
+            array_name = path_parts[-1]
+            logger.info(f"Saving XPS image to {'/'.join(path_parts)}")
+            
+            if array_name not in current:
+                current.write_array(image_array, key=array_name)
+            else:
+                logger.debug(f"Array {array_name} already exists, skipping write")
+
+            # Mark as saved
+            self.saved_images.add(image_key)
+            return True
+
+        except Exception as e:
+            logger.error(f"Error saving XPS image to Tiled: {e}")
+            import traceback
+            logger.error(traceback.format_exc())
+            return False
+
+    async def publish(self, message):
+        """Publish a message to Tiled server."""
+        if isinstance(message, SASStop):
+            logger.info("Received Stop message")
+            return
+
+        if not isinstance(message, RawFrameEvent):
+            return
+
+        try:
+            # Extract image data from message
+            image_array = message.image.array
+            tiled_url = message.tiled_url
+            frame_number = message.frame_number if hasattr(message, 'frame_number') else 0
+
+            # Save the image in a separate thread
+            success = await asyncio.to_thread(
+                self._save_image_sync, 
+                image_array, 
+                tiled_url
+            )
+
+            if success:
+                logger.info(f"XPS image saved successfully to: {tiled_url}")
+                return tiled_url
+            else:
+                logger.warning(f"Failed to save XPS image from frame {frame_number}")
+                return None
+
+        except Exception as e:
+            logger.error(f"Error publishing XPS data to Tiled: {e}")
+            import traceback
+            logger.error(traceback.format_exc())
+            return None
+
+    @classmethod
+    def from_settings(cls, settings):
+        """Create an XPSTiledLocalImagePublisher from settings."""
+        return cls()
+
+    def get_local_url_for(self, original_url):
+        """
+        For XPS, the original URL is already the local URL, so just return it if saved.
+        """
+        if not original_url:
+            return None
+
+        # Extract path and check if we saved it
+        path_parts = self._extract_path_from_url(original_url)
+        if not path_parts:
+            return None
+        
+        image_key = '/'.join(path_parts)
+        
+        if image_key in self.saved_images:
+            return original_url
+        
+        return None

--- a/src/arroyo_reduction/xps_websocket_listener.py
+++ b/src/arroyo_reduction/xps_websocket_listener.py
@@ -3,25 +3,33 @@ import json
 import logging
 import msgpack
 import numpy as np
+import os
 import websockets
+import uuid
 from arroyopy.listener import Listener
 from arroyopy.operator import Operator
 from arroyosas.schemas import RawFrameEvent, NumpyArrayModel
 
 logger = logging.getLogger("arroyo_reduction.xps_websocket_listener")
 
+# Read base URL from environment variable
+RESULTS_TILED_URI = os.getenv("RESULTS_TILED_URI", "http://tiled:8000")
 
-class XPSWebSocketListener(Listener):  # ← Inherit from Listener
+
+class XPSWebSocketListener(Listener):
     """Listen to XPS websocket and process shot_mean data"""
     
-    def __init__(self, operator: Operator, websocket_url: str):  # ← Operator first (like ZMQ)
+    def __init__(self, operator: Operator, websocket_url: str):
         self.operator = operator
         self.websocket_url = websocket_url
         self.should_stop = False
+        self.current_uuid = None  # Track current run UUID
+        self.tiled_base_uri = RESULTS_TILED_URI  # Store base URI
         
     async def start(self):
         """Connect to XPS websocket and listen for messages"""
         logger.info(f"XPS WebSocket listen loop started on {self.websocket_url}")
+        logger.info(f"Using Tiled base URI: {self.tiled_base_uri}")
         
         while not self.should_stop:
             try:
@@ -64,16 +72,25 @@ class XPSWebSocketListener(Listener):  # ← Inherit from Listener
             logger.warning("Received XPS message without shot_mean data")
             return
         
+        # Generate new UUID when frame_number is 0 (start of new run)
+        if shot_num == 0:
+            self.current_uuid = str(uuid.uuid4())
+            logger.info(f"Starting new XPS run with UUID: {self.current_uuid}")
+        
         # Convert uint8 bytes back to numpy array
         shot_mean = np.frombuffer(shot_mean_bytes, dtype=np.uint8)
         
         logger.debug(f"Received shot_mean for shot {shot_num}: shape {shot_mean.shape}")
         
+        # Define the target tiled_url where the image should be saved
+        # Format: base_url/api/v1/array/full/beamlines/bl931/processed/live_data_cache/UUID/xps_averaged_heatmaps/frame_N
+        tiled_url = f"{self.tiled_base_uri}/api/v1/array/full/beamlines/bl931/processed/live_data_cache/{self.current_uuid}/xps_averaged_heatmaps/frame_{shot_num}?slice=0:1,0:{height},0:{width}"
+        
         # Create a RawFrameEvent compatible with the operator
         frame_event = RawFrameEvent(
             image=NumpyArrayModel(array=shot_mean),
             frame_number=shot_num,
-            tiled_url=f"xps_shot_{shot_num}"
+            tiled_url=tiled_url
         )
         
         # Process through operator

--- a/src/arroyo_reduction/xps_websocket_listener.py
+++ b/src/arroyo_reduction/xps_websocket_listener.py
@@ -8,7 +8,7 @@ import websockets
 import uuid
 from arroyopy.listener import Listener
 from arroyopy.operator import Operator
-from arroyosas.schemas import RawFrameEvent, NumpyArrayModel
+from arroyosas.schemas import RawFrameEvent, SerializableNumpyArrayModel
 
 logger = logging.getLogger("arroyo_reduction.xps_websocket_listener")
 
@@ -73,12 +73,12 @@ class XPSWebSocketListener(Listener):
             return
         
         # Generate new UUID when frame_number is 0 (start of new run)
-        if shot_num == 0:
+        if shot_num == 1:
             self.current_uuid = str(uuid.uuid4())
             logger.info(f"Starting new XPS run with UUID: {self.current_uuid}")
         
         # Convert uint8 bytes back to numpy array
-        shot_mean = np.frombuffer(shot_mean_bytes, dtype=np.uint8)
+        shot_mean = np.frombuffer(shot_mean_bytes, dtype=np.uint8).reshape(width, height)
         
         logger.debug(f"Received shot_mean for shot {shot_num}: shape {shot_mean.shape}")
         
@@ -88,7 +88,7 @@ class XPSWebSocketListener(Listener):
         
         # Create a RawFrameEvent compatible with the operator
         frame_event = RawFrameEvent(
-            image=NumpyArrayModel(array=shot_mean),
+            image=SerializableNumpyArrayModel(array=shot_mean),
             frame_number=shot_num,
             tiled_url=tiled_url
         )

--- a/src/arroyo_reduction/xps_websocket_listener.py
+++ b/src/arroyo_reduction/xps_websocket_listener.py
@@ -1,0 +1,92 @@
+import asyncio
+import json
+import logging
+import msgpack
+import numpy as np
+import websockets
+from arroyopy.listener import Listener
+from arroyopy.operator import Operator
+from arroyosas.schemas import RawFrameEvent, NumpyArrayModel
+
+logger = logging.getLogger("arroyo_reduction.xps_websocket_listener")
+
+
+class XPSWebSocketListener(Listener):  # ← Inherit from Listener
+    """Listen to XPS websocket and process shot_mean data"""
+    
+    def __init__(self, operator: Operator, websocket_url: str):  # ← Operator first (like ZMQ)
+        self.operator = operator
+        self.websocket_url = websocket_url
+        self.should_stop = False
+        
+    async def start(self):
+        """Connect to XPS websocket and listen for messages"""
+        logger.info(f"XPS WebSocket listen loop started on {self.websocket_url}")
+        
+        while not self.should_stop:
+            try:
+                async with websockets.connect(self.websocket_url) as websocket:
+                    logger.info("Connected to XPS websocket")
+                    
+                    async for message in websocket:
+                        if self.should_stop:
+                            break
+                        try:
+                            await self._handle_message(message)
+                        except Exception as e:
+                            logger.exception(f"Error processing message: {e}")
+                        
+            except websockets.ConnectionClosed:
+                logger.warning("XPS websocket connection closed, reconnecting in 5s...")
+                await asyncio.sleep(5)
+            except Exception as e:
+                logger.error(f"Error in XPS websocket connection: {e}")
+                await asyncio.sleep(5)
+    
+    async def _handle_message(self, message):
+        """Parse XPS message and extract shot_mean for processing"""
+        # First message is JSON with metadata (skip it)
+        if isinstance(message, str):
+            data = json.loads(message)
+            logger.debug(f"Received XPS metadata: {data}")
+            return
+        
+        # Second message is msgpack with images
+        data = msgpack.unpackb(message)
+        
+        # Extract shot_mean (the averaged heatmap)
+        shot_mean_bytes = data.get('shot_mean')
+        width = data.get('width')
+        height = data.get('height')
+        shot_num = data.get('shot_num', 0)
+        
+        if not shot_mean_bytes or not width or not height:
+            logger.warning("Received XPS message without shot_mean data")
+            return
+        
+        # Convert uint8 bytes back to numpy array
+        shot_mean = np.frombuffer(shot_mean_bytes, dtype=np.uint8)
+        
+        logger.debug(f"Received shot_mean for shot {shot_num}: shape {shot_mean.shape}")
+        
+        # Create a RawFrameEvent compatible with the operator
+        frame_event = RawFrameEvent(
+            image=NumpyArrayModel(array=shot_mean),
+            frame_number=shot_num,
+            tiled_url=f"xps_shot_{shot_num}"
+        )
+        
+        # Process through operator
+        await self.operator.process(frame_event)
+    
+    async def stop(self):
+        """Stop the listener"""
+        logger.info("Stopping XPS websocket listener")
+        self.should_stop = True
+    
+    @classmethod
+    def from_settings(cls, settings: dict, operator: Operator) -> "XPSWebSocketListener":
+        """Create listener from settings (consistent with ZMQFrameListener)"""
+        websocket_url = settings.websocket_url
+        logger.info(f"##### Listening for XPS frames on {websocket_url}")
+        return cls(operator, websocket_url)

--- a/src/assets/clientside.js
+++ b/src/assets/clientside.js
@@ -91,23 +91,33 @@ window.dash_clientside = Object.assign({}, window.dash_clientside, {
                         let dimred_model = data.dimred_model;
                         log.debug("Message models - Autoencoder:", autoencoder_model, "Dimred:", dimred_model);
 
-                        // Check if model names match currently selected models
+                        // MODIFIED SECTION START - Compare full "name:version" identifiers
                         if (selected_models !== null && selected_models !== undefined) {
-                            let current_autoencoder = selected_models.autoencoder;
-                            let current_dimred = selected_models.dimred;
-                            log.debug("Current selected models - Autoencoder:", current_autoencoder, "Dimred:", current_dimred);
+                            // Construct full identifiers from selected_models
+                            let current_autoencoder_id = selected_models.autoencoder;
+                            let current_dimred_id = selected_models.dimred;
+                            
+                            // Add version if available
+                            if (selected_models.autoencoder_version) {
+                                current_autoencoder_id = `${selected_models.autoencoder}:${selected_models.autoencoder_version}`;
+                            }
+                            if (selected_models.dimred_version) {
+                                current_dimred_id = `${selected_models.dimred}:${selected_models.dimred_version}`;
+                            }
+                            
+                            log.debug("Current selected model IDs - Autoencoder:", current_autoencoder_id, "Dimred:", current_dimred_id);
 
-                            // Skip buffer entries from different models
-                            if ((autoencoder_model && autoencoder_model !== current_autoencoder) ||
-                                (dimred_model && dimred_model !== current_dimred)) {
-                                log.info(`Skipping buffer entries from different models: got ${autoencoder_model}/${dimred_model}, expected ${current_autoencoder}/${current_dimred}`);
+                            // Skip buffer entries from different model versions
+                            if ((autoencoder_model && autoencoder_model !== current_autoencoder_id) ||
+                                (dimred_model && dimred_model !== current_dimred_id)) {
+                                log.info(`Skipping buffer entries from different model versions: got ${autoencoder_model}/${dimred_model}, expected ${current_autoencoder_id}/${current_dimred_id}`);
 
                                 // Return current state without modifications when models don't match
                                 return [buffer_data, data_project_dict, live_indices, spinner_style, transition_state];
                             }
 
                             // If we got a matching model message, hide the spinner
-                            log.info("Models match - hiding spinner");
+                            log.info("Model versions match - hiding spinner");
                             spinner_style = {
                                 "position": "fixed",
                                 "top": 0,
@@ -120,6 +130,7 @@ window.dash_clientside = Object.assign({}, window.dash_clientside, {
                             };
                             transition_state = false;
                         }
+                        // MODIFIED SECTION END
 
                         // Process the data
                         let new_entry = {};
@@ -168,6 +179,7 @@ window.dash_clientside = Object.assign({}, window.dash_clientside, {
                         // Check for slice index in the query string
                         const params = new URLSearchParams(url.search);
                         const sliceParam = params.get('slice');
+                        let index = 0;
 
                         if (sliceParam) {
                             // Expecting format like "0,0,:,:" or "0:1,0:1679,0:1475"

--- a/src/assets/clientside.js
+++ b/src/assets/clientside.js
@@ -91,7 +91,7 @@ window.dash_clientside = Object.assign({}, window.dash_clientside, {
                         let dimred_model = data.dimred_model;
                         log.debug("Message models - Autoencoder:", autoencoder_model, "Dimred:", dimred_model);
 
-                        // MODIFIED SECTION START - Compare full "name:version" identifiers
+                        // Compare full "name:version" identifiers
                         if (selected_models !== null && selected_models !== undefined) {
                             // Construct full identifiers from selected_models
                             let current_autoencoder_id = selected_models.autoencoder;
@@ -130,7 +130,6 @@ window.dash_clientside = Object.assign({}, window.dash_clientside, {
                             };
                             transition_state = false;
                         }
-                        // MODIFIED SECTION END
 
                         // Process the data
                         let new_entry = {};

--- a/src/callbacks/display.py
+++ b/src/callbacks/display.py
@@ -11,7 +11,7 @@ from file_manager.data_project import DataProject
 from mlex_utils.prefect_utils.core import get_children_flow_run_ids
 from PIL import Image
 
-from src.app_layout import DATA_TILED_KEY, REMOTE_DATA_TILED_KEY, NUM_IMGS_OVERVIEW, USER
+from src.app_layout import DATA_TILED_KEY, LIVE_TILED_API_KEY, NUM_IMGS_OVERVIEW, USER
 from src.utils.data_utils import hash_list_of_strings, tiled_results
 from src.utils.plot_utils import (
     generate_heatmap_plot,
@@ -382,12 +382,12 @@ def update_heatmap(
     
     if is_live_mode:
         # Use remote API key for live mode
-        api_key = REMOTE_DATA_TILED_KEY
-        logger.info("Using REMOTE_DATA_TILED_KEY for live mode heatmap")
+        api_key = LIVE_TILED_API_KEY
+        logger.info("Using LIVE_TILED_API_KEY for live mode heatmap")
     elif is_replay_mode:
         # Use remote API key for replay mode
-        api_key = REMOTE_DATA_TILED_KEY
-        logger.info("Using REMOTE_DATA_TILED_KEY for replay mode heatmap")
+        api_key = LIVE_TILED_API_KEY
+        logger.info("Using LIVE_TILED_API_KEY for replay mode heatmap")
     else:
         # Use regular DATA_TILED_KEY for offline mode
         api_key = DATA_TILED_KEY

--- a/src/callbacks/display.py
+++ b/src/callbacks/display.py
@@ -11,7 +11,7 @@ from file_manager.data_project import DataProject
 from mlex_utils.prefect_utils.core import get_children_flow_run_ids
 from PIL import Image
 
-from src.app_layout import DATA_TILED_KEY, LIVE_TILED_API_KEY, NUM_IMGS_OVERVIEW, USER
+from src.app_layout import DATA_TILED_KEY, LIVE_TILED_API_KEY, NUM_IMGS_OVERVIEW, USER, long_callback_manager
 from src.utils.data_utils import hash_list_of_strings, tiled_results
 from src.utils.plot_utils import (
     generate_heatmap_plot,
@@ -19,6 +19,8 @@ from src.utils.plot_utils import (
     plot_empty_heatmap,
     plot_empty_scatter,
 )
+
+MAX_HEATMAP_SELECTION = 30
 
 # Add logger for display.py
 logger = logging.getLogger("lse.display")
@@ -320,16 +322,27 @@ def clear_selections(n_clicks, current_fig):
 
 
 @callback(
-    Output("heatmap", "figure"),
-    Output("stats-div", "children", allow_duplicate=True),
-    Input("scatter", "clickData"),
-    Input("scatter", "selectedData"),
-    Input("mean-std-toggle", "value"),
-    Input("log-transform", "value"),
-    Input("min-max-percentile", "value"),
-    State({"base_id": "file-manager", "name": "data-project-dict"}, "data"),
-    State("live-indices", "data"),
-    State("go-live", "n_clicks"),  # Add state for live mode
+    output=[
+        Output("heatmap", "figure"),
+        Output("stats-div", "children", allow_duplicate=True),
+    ],
+    inputs=[
+        Input("scatter", "clickData"),
+        Input("scatter", "selectedData"),
+        Input("mean-std-toggle", "value"),
+        Input("log-transform", "value"),
+        Input("min-max-percentile", "value"),
+    ],
+    state=[
+        State({"base_id": "file-manager", "name": "data-project-dict"}, "data"),
+        State("live-indices", "data"),
+        State("go-live", "n_clicks"),
+    ],
+    background=True,  # This makes it a long callback
+    manager=long_callback_manager,
+    running=[
+        (Output("stats-div", "children"), "Loading heatmap...", ""),
+    ],
     prevent_initial_call=True,
 )
 def update_heatmap(
@@ -340,7 +353,7 @@ def update_heatmap(
     percentiles,
     data_project_dict,
     live_indices,
-    go_live,  # New state parameter for live mode detection
+    go_live,
 ):
     """
     This callback update the heatmap
@@ -355,10 +368,19 @@ def update_heatmap(
         go_live:                n_clicks for live mode button
     Returns:
         fig:                    updated heatmap
+        stats:                  statistics text
     """
     # user select a group of points
     if selected_data is not None and len(selected_data["points"]) > 0:
         selected_indices = [point["pointIndex"] for point in selected_data["points"]]
+        
+        # Check if selection exceeds limit
+        if len(selected_indices) > MAX_HEATMAP_SELECTION:
+            return (
+                plot_empty_heatmap(),
+                f"⚠️ Selection too large ({len(selected_indices)} points). "
+                f"Please select {MAX_HEATMAP_SELECTION} or fewer points for heatmap display.",
+            )
 
     # user click on a single point
     elif click_data is not None and len(click_data["points"]) > 0:

--- a/src/callbacks/display.py
+++ b/src/callbacks/display.py
@@ -50,6 +50,11 @@ def update_data_overview(
 ):
     if go_live is not None and go_live % 2 == 1:
         raise PreventUpdate
+    
+    # Skip if in replay mode - check for the replay_mode flag
+    if data_project_dict and data_project_dict.get("replay_mode", False):
+        raise PreventUpdate
+    
     imgs = []
     if data_project_dict != {}:
         data_project = DataProject.from_dict(data_project_dict, api_key=DATA_TILED_KEY)
@@ -329,11 +334,16 @@ def update_heatmap(
 
     # Determine which API key to use based on live mode
     is_live_mode = go_live is not None and go_live % 2 == 1
+    is_replay_mode = data_project_dict.get("replay_mode", False)
     
     if is_live_mode:
         # Use remote API key for live mode
         api_key = REMOTE_DATA_TILED_KEY
         logger.info("Using REMOTE_DATA_TILED_KEY for live mode heatmap")
+    elif is_replay_mode:
+        # Use remote API key for replay mode
+        api_key = REMOTE_DATA_TILED_KEY
+        logger.info("Using REMOTE_DATA_TILED_KEY for replay mode heatmap")
     else:
         # Use regular DATA_TILED_KEY for offline mode
         api_key = DATA_TILED_KEY

--- a/src/callbacks/display.py
+++ b/src/callbacks/display.py
@@ -370,16 +370,19 @@ def update_heatmap(
         fig:                    updated heatmap
         stats:                  statistics text
     """
+    # Check if in live mode
+    is_live_mode = go_live is not None and go_live % 2 == 1
+    
     # user select a group of points
     if selected_data is not None and len(selected_data["points"]) > 0:
         selected_indices = [point["pointIndex"] for point in selected_data["points"]]
         
-        # Check if selection exceeds limit
-        if len(selected_indices) > MAX_HEATMAP_SELECTION:
+        # Only apply MAX_HEATMAP_SELECTION limit in live mode
+        if is_live_mode and len(selected_indices) > MAX_HEATMAP_SELECTION:
             return (
                 plot_empty_heatmap(),
                 f"⚠️ Selection too large ({len(selected_indices)} points). "
-                f"Please select {MAX_HEATMAP_SELECTION} or fewer points for heatmap display.",
+                f"Please select {MAX_HEATMAP_SELECTION} or fewer points for heatmap display in live mode.",
             )
 
     # user click on a single point
@@ -399,7 +402,6 @@ def update_heatmap(
         selected_indices = [live_indices[i] for i in selected_indices]
 
     # Determine which API key to use based on live mode
-    is_live_mode = go_live is not None and go_live % 2 == 1
     is_replay_mode = data_project_dict.get("replay_mode", False)
     
     if is_live_mode:

--- a/src/callbacks/experiment_replay.py
+++ b/src/callbacks/experiment_replay.py
@@ -41,12 +41,78 @@ def toggle_load_button(selected_uuid):
     """Enable/disable load button based on UUID selection"""
     return selected_uuid is None
 
+@callback(
+    Output("scatter", "figure", allow_duplicate=True),
+    Output("stats-div", "children", allow_duplicate=True),
+    Input("replay-data-percentage", "value"),
+    State("replay-buffer", "data"),
+    State({"base_id": "file-manager", "name": "data-project-dict"}, "data"),
+    prevent_initial_call=True,
+)
+def filter_experiment_by_percentage(percentage_range, replay_buffer, data_project_dict):
+    """Filter experiment data by percentage range"""
+    # Check if buffer is empty or doesn't have feature_vectors
+    if not replay_buffer or "feature_vectors" not in replay_buffer:
+        raise PreventUpdate
+        
+    # Check if we're in replay mode
+    if not data_project_dict or not data_project_dict.get("replay_mode", False):
+        raise PreventUpdate
+        
+    try:
+        # Get the feature vectors from the replay buffer
+        feature_vectors_full = np.array(replay_buffer["feature_vectors"])
+        
+        total_points = len(feature_vectors_full)
+        if total_points == 0:
+            raise PreventUpdate
+            
+        # Calculate the range indices based on percentage
+        start_percent, end_percent = percentage_range
+        
+        # Handle full range (0-100) the same way as partial ranges
+        start_idx = int((start_percent / 100) * total_points)
+        end_idx = int((end_percent / 100) * total_points)
+        
+        # Ensure at least one point is shown
+        end_idx = max(end_idx, start_idx + 1)
+        
+        # Create filtered data
+        filtered_vectors = feature_vectors_full[start_idx:end_idx]
+        
+        # Get experiment UUID
+        experiment_uuid = replay_buffer.get("uuid", "unknown")
+        
+        # Rebuild the scatter plot if we have vectors
+        if len(filtered_vectors) > 0:
+            n_components = filtered_vectors.shape[1]
+            
+            # Create a new scatter plot
+            scatter_fig = generate_scatter_data(filtered_vectors, n_components)
+            
+            # Update stats text
+            if start_percent == 0 and end_percent == 100:
+                stats_text = f"Showing all {len(filtered_vectors)} feature vectors from experiment {experiment_uuid}"
+            else:
+                stats_text = f"Showing {len(filtered_vectors)} feature vectors ({start_percent}% - {end_percent}% of data) from experiment {experiment_uuid}"
+            
+            return scatter_fig, stats_text
+                
+        # If we get here, we couldn't create a valid plot
+        return no_update, f"No data available in the selected range ({start_percent}% - {end_percent}%)"
+        
+    except Exception as e:
+        logger.error(f"Error filtering experiment data: {e}")
+        logger.error(traceback.format_exc())
+        return no_update, f"Error filtering data: {str(e)}"
+
 
 @callback(
     Output("scatter", "figure", allow_duplicate=True),
     Output("stats-div", "children", allow_duplicate=True),
     Output({"base_id": "file-manager", "name": "data-project-dict"}, "data", allow_duplicate=True),
-    Output("live-indices", "data", allow_duplicate=True),  # Add live-indices output
+    Output("replay-buffer", "data"),  # Use our new replay-buffer with structured format
+    Output("replay-data-percentage", "value"),  # Reset the slider
     Input("load-experiment-button", "n_clicks"),
     State("experiment-uuid-dropdown", "value"),
     prevent_initial_call=True,
@@ -65,22 +131,26 @@ def load_experiment_replay(n_clicks, selected_uuid):
         "replay_mode": True  # Flag to prevent update_data_overview from running
     }
     
-    # Initialize an empty list for the indices
-    live_indices = []
+    # Initialize an empty structured replay buffer
+    replay_buffer = {
+        "feature_vectors": [],
+        "live_indices": [],
+        "uuid": selected_uuid
+    }
     
     try:
         # Connect to Tiled and load feature vectors
         logger.info(f"Loading experiment UUID: {selected_uuid}")
         
         if not tiled_results.check_dataloader_ready():
-            return no_update, f"Could not connect to Tiled server", data_project_dict, live_indices
+            return no_update, f"Could not connect to Tiled server", data_project_dict, replay_buffer, [0, 100]
 
         # Build the path to the selected experiment table
         container = tiled_results.data_client
         
         # Navigate to lse_live_results/daily_run_YYYY-MM-DD/selected_uuid
         if "lse_live_results" not in container:
-            return no_update, "lse_live_results container not found in Tiled", data_project_dict, live_indices
+            return no_update, "lse_live_results container not found in Tiled", data_project_dict, replay_buffer, [0, 100]
             
         container = container["lse_live_results"]
         
@@ -88,7 +158,7 @@ def load_experiment_replay(n_clicks, selected_uuid):
         daily_runs = sorted([k for k in container.keys() if k.startswith("daily_run_")], reverse=True)
         
         if not daily_runs:
-            return no_update, "No experiment data found", data_project_dict, live_indices
+            return no_update, "No experiment data found", data_project_dict, replay_buffer, [0, 100]
             
         # Get the latest daily run containing our UUID
         df = None
@@ -105,12 +175,12 @@ def load_experiment_replay(n_clicks, selected_uuid):
                 continue
         
         if df is None:
-            return no_update, f"Could not load data for experiment {selected_uuid}", data_project_dict, live_indices
+            return no_update, f"Could not load data for experiment {selected_uuid}", data_project_dict, replay_buffer, [0, 100]
         
         # Extract feature vectors from DataFrame
         feature_cols = [col for col in df.columns if col.startswith('feature_')]
         if not feature_cols:
-            return no_update, "No feature vectors found in the selected data", data_project_dict, live_indices
+            return no_update, "No feature vectors found in the selected data", data_project_dict, replay_buffer, [0, 100]
             
         # Create numpy array with feature vectors
         import numpy as np
@@ -126,6 +196,7 @@ def load_experiment_replay(n_clicks, selected_uuid):
         tiled_urls = df['tiled_url'].tolist() if 'tiled_url' in df.columns else []
         
         # Extract slice indices from URLs
+        live_indices = []
         if tiled_urls:
             import re
             
@@ -148,21 +219,19 @@ def load_experiment_replay(n_clicks, selected_uuid):
             logger.info(f"Extracted {sum(1 for idx in live_indices if idx >= 0)} slice indices")
             logger.info(f"Sample indices: {live_indices[:5]}")
         
-        # Log some sample URLs
-        if tiled_urls:
-            url_sample_size = min(3, len(tiled_urls))
-            logger.info(f"Sample tiled_urls (first {url_sample_size}):")
-            for i, url in enumerate(tiled_urls[:url_sample_size]):
-                logger.info(f"URL {i}: {url}")
-        else:
-            logger.info("No tiled_urls found in DataFrame")
-        
         # Create a scatter plot from the feature vectors
         n_components = 2  # Default to 2D
         if feature_vectors.shape[1] > 2:
             n_components = min(3, feature_vectors.shape[1])
             
         scatter_fig = generate_scatter_data(feature_vectors, n_components)
+        
+        # Store data in the replay buffer
+        replay_buffer = {
+            "feature_vectors": feature_vectors.tolist(),
+            "live_indices": live_indices,
+            "uuid": selected_uuid
+        }
         
         # Let's try to create a more complete data project dictionary
         # Extract information from the first URL if available
@@ -231,9 +300,9 @@ def load_experiment_replay(n_clicks, selected_uuid):
         # Success message
         stats_text = f"Loaded {len(df)} feature vectors from experiment {selected_uuid}"
         
-        return scatter_fig, stats_text, data_project_dict, live_indices
+        return scatter_fig, stats_text, data_project_dict, replay_buffer, [0, 100]
             
     except Exception as e:
         logger.error(f"Error loading experiment: {e}")
         logger.error(traceback.format_exc())
-        return no_update, f"Error loading experiment: {str(e)}", data_project_dict, live_indices
+        return no_update, f"Error loading experiment: {str(e)}", data_project_dict, replay_buffer, [0, 100]

--- a/src/callbacks/experiment_replay.py
+++ b/src/callbacks/experiment_replay.py
@@ -15,22 +15,33 @@ from src.utils.plot_utils import (
 
 logger = logging.getLogger("lse.replay")
 
-
 @callback(
     Output("daily-container-dropdown", "options"),
     Output("daily-container-dropdown", "value"),
-    Input("refresh-daily-containers", "n_clicks"),  # Updated button ID
-    Input("sidebar", "active_item"),  # Also load when sidebar tab is selected
+    Input("refresh-daily-containers", "n_clicks"),
     prevent_initial_call=True,
 )
-def load_daily_containers(n_clicks, active_item):
+def load_daily_containers(n_clicks):
     """Load available daily containers from Tiled"""
+    if n_clicks is None:
+        raise PreventUpdate
+        
     containers = get_daily_containers()
     
     if containers:
         return containers, containers[0]["value"]
     else:
         return [], None
+    
+@callback(
+    Output("daily-container-dropdown", "options", allow_duplicate=True),
+    Input("sidebar", "active_item"),
+    prevent_initial_call="initial_duplicate",
+)
+def load_containers_on_render(active_item):
+    """Load daily containers when the page is first loaded"""
+    containers = get_daily_containers()
+    return containers if containers else []
         
 @callback(
     Output("experiment-uuid-dropdown", "options"),

--- a/src/callbacks/experiment_replay.py
+++ b/src/callbacks/experiment_replay.py
@@ -1,0 +1,38 @@
+import logging
+
+import pandas as pd
+import numpy as np
+from dash import Input, Output, State, callback, no_update
+from dash.exceptions import PreventUpdate
+
+from src.utils.data_utils import get_available_experiment_uuids, tiled_results
+from src.utils.plot_utils import generate_scatter_data, plot_empty_scatter
+
+logger = logging.getLogger("lse.replay")
+
+
+@callback(
+    Output("experiment-uuid-dropdown", "options"),
+    Output("experiment-uuid-dropdown", "value"),
+    Input("refresh-experiment-uuids", "n_clicks"),
+    Input("sidebar", "active_item"),  # Also load when sidebar tab is selected
+    prevent_initial_call=True,
+)
+def load_experiment_uuids(n_clicks, active_item):
+    """Load available experiment UUIDs from Tiled"""
+    uuids = get_available_experiment_uuids()
+    
+    if uuids:
+        return uuids, uuids[0]["value"]
+    else:
+        return [], None
+
+
+@callback(
+    Output("load-experiment-button", "disabled"),
+    Input("experiment-uuid-dropdown", "value"),
+)
+def toggle_load_button(selected_uuid):
+    """Enable/disable load button based on UUID selection"""
+    return selected_uuid is None
+

--- a/src/callbacks/experiment_replay.py
+++ b/src/callbacks/experiment_replay.py
@@ -1,12 +1,17 @@
 import logging
-
-import pandas as pd
+import traceback
 import numpy as np
 from dash import Input, Output, State, callback, no_update
 from dash.exceptions import PreventUpdate
+from file_manager.data_project import DataProject
 
 from src.utils.data_utils import get_available_experiment_uuids, tiled_results
-from src.utils.plot_utils import generate_scatter_data, plot_empty_scatter
+from src.utils.plot_utils import (
+    generate_scatter_data, 
+    plot_empty_heatmap, 
+    plot_empty_scatter,
+    generate_notification
+)
 
 logger = logging.getLogger("lse.replay")
 
@@ -36,3 +41,199 @@ def toggle_load_button(selected_uuid):
     """Enable/disable load button based on UUID selection"""
     return selected_uuid is None
 
+
+@callback(
+    Output("scatter", "figure", allow_duplicate=True),
+    Output("stats-div", "children", allow_duplicate=True),
+    Output({"base_id": "file-manager", "name": "data-project-dict"}, "data", allow_duplicate=True),
+    Output("live-indices", "data", allow_duplicate=True),  # Add live-indices output
+    Input("load-experiment-button", "n_clicks"),
+    State("experiment-uuid-dropdown", "value"),
+    prevent_initial_call=True,
+)
+def load_experiment_replay(n_clicks, selected_uuid):
+    """Load feature vectors from selected experiment UUID and display in scatter plot"""
+    if not n_clicks or not selected_uuid:
+        raise PreventUpdate
+    
+    # Initialize a minimal data project dictionary with replay_mode flag
+    data_project_dict = {
+        "root_uri": "",
+        "data_type": "tiled",
+        "datasets": [],
+        "project_id": f"replay_{selected_uuid}",
+        "replay_mode": True  # Flag to prevent update_data_overview from running
+    }
+    
+    # Initialize an empty list for the indices
+    live_indices = []
+    
+    try:
+        # Connect to Tiled and load feature vectors
+        logger.info(f"Loading experiment UUID: {selected_uuid}")
+        
+        if not tiled_results.check_dataloader_ready():
+            return no_update, f"Could not connect to Tiled server", data_project_dict, live_indices
+
+        # Build the path to the selected experiment table
+        container = tiled_results.data_client
+        
+        # Navigate to lse_live_results/daily_run_YYYY-MM-DD/selected_uuid
+        if "lse_live_results" not in container:
+            return no_update, "lse_live_results container not found in Tiled", data_project_dict, live_indices
+            
+        container = container["lse_live_results"]
+        
+        # Find the most recent daily run container
+        daily_runs = sorted([k for k in container.keys() if k.startswith("daily_run_")], reverse=True)
+        
+        if not daily_runs:
+            return no_update, "No experiment data found", data_project_dict, live_indices
+            
+        # Get the latest daily run containing our UUID
+        df = None
+        run_used = None
+        for run in daily_runs:
+            try:
+                if selected_uuid in container[run]:
+                    df = container[run][selected_uuid].read()
+                    run_used = run
+                    logger.info(f"Loaded DataFrame with shape: {df.shape} from run: {run}")
+                    break
+            except Exception as e:
+                logger.warning(f"Error loading data from {run}/{selected_uuid}: {e}")
+                continue
+        
+        if df is None:
+            return no_update, f"Could not load data for experiment {selected_uuid}", data_project_dict, live_indices
+        
+        # Extract feature vectors from DataFrame
+        feature_cols = [col for col in df.columns if col.startswith('feature_')]
+        if not feature_cols:
+            return no_update, "No feature vectors found in the selected data", data_project_dict, live_indices
+            
+        # Create numpy array with feature vectors
+        import numpy as np
+        feature_vectors = df[feature_cols].values
+        
+        # Log sample of feature vectors (first 3 rows)
+        sample_size = min(3, feature_vectors.shape[0])
+        logger.info(f"Sample feature vectors (first {sample_size} rows):")
+        for i, sample in enumerate(feature_vectors[:sample_size]):
+            logger.info(f"Row {i}: {sample}")
+        
+        # Extract tiled_urls for reference
+        tiled_urls = df['tiled_url'].tolist() if 'tiled_url' in df.columns else []
+        
+        # Extract slice indices from URLs
+        if tiled_urls:
+            import re
+            
+            # Initialize live_indices as a list of the same length as feature_vectors
+            live_indices = [-1] * len(feature_vectors)
+            
+            # Extract slice indices from URLs
+            for i, url in enumerate(tiled_urls):
+                # Look for slice parameter in the URL
+                slice_match = re.search(r'slice=(\d+):', url)
+                if slice_match:
+                    slice_index = int(slice_match.group(1))
+                    live_indices[i] = slice_index
+                    
+                    # Log some samples for debugging
+                    if i < 3:
+                        logger.info(f"URL {i}: Extracted slice index {slice_index} from {url}")
+            
+            # Log the slice indices
+            logger.info(f"Extracted {sum(1 for idx in live_indices if idx >= 0)} slice indices")
+            logger.info(f"Sample indices: {live_indices[:5]}")
+        
+        # Log some sample URLs
+        if tiled_urls:
+            url_sample_size = min(3, len(tiled_urls))
+            logger.info(f"Sample tiled_urls (first {url_sample_size}):")
+            for i, url in enumerate(tiled_urls[:url_sample_size]):
+                logger.info(f"URL {i}: {url}")
+        else:
+            logger.info("No tiled_urls found in DataFrame")
+        
+        # Create a scatter plot from the feature vectors
+        n_components = 2  # Default to 2D
+        if feature_vectors.shape[1] > 2:
+            n_components = min(3, feature_vectors.shape[1])
+            
+        scatter_fig = generate_scatter_data(feature_vectors, n_components)
+        
+        # Let's try to create a more complete data project dictionary
+        # Extract information from the first URL if available
+        if tiled_urls:
+            try:
+                from urllib.parse import urlparse
+                
+                # Parse the first URL
+                first_url = urlparse(tiled_urls[0])
+                
+                # Extract base URI
+                base_uri = f"{first_url.scheme}://{first_url.netloc}"
+                logger.info(f"Base URI extracted: {base_uri}")
+                
+                # Extract path components
+                path = first_url.path
+                logger.info(f"Path from URL: {path}")
+                
+                # Extract slice info from query
+                query = first_url.query
+                logger.info(f"Query from URL: {query}")
+                
+                # Try to create a useful dataset structure
+                # Typically path will be like /api/v1/array/full/smi/raw/UUID/primary/data/pil2M_image
+                parts = path.split('/api/v1/')
+                if len(parts) > 1:
+                    uri_path = parts[1]
+                    logger.info(f"Path after /api/v1/: {uri_path}")
+                    
+                    if uri_path.startswith(('array/full/', 'metadata/')):
+                        uri_path = uri_path.split('/', 2)[2]  # Get path after array/full/ or metadata/
+                        logger.info(f"Final URI path: {uri_path}")
+                    
+                    # Create a dataset with this path
+                    datasets = [
+                        {
+                            "uri": uri_path,
+                            "cumulative_data_count": len(df)
+                        }
+                    ]
+                    
+                    # Create data project with the extracted components
+                    data_project_dict = {
+                        "root_uri": f"{base_uri}/api/v1/metadata",
+                        "data_type": "tiled",
+                        "datasets": datasets,
+                        "project_id": f"replay_{selected_uuid}",
+                        "replay_mode": True  # Keep the replay_mode flag
+                    }
+                else:
+                    # Fallback if parsing fails - use the initialized data_project_dict
+                    pass
+            except Exception as e:
+                logger.warning(f"Error parsing URL for data project: {e}")
+                # Fallback to the initialized data_project_dict
+                pass
+        else:
+            # No URLs available - use the initialized data_project_dict
+            pass
+        
+        # Log the final data project dictionary
+        import json
+        logger.info(f"Created data project dictionary:")
+        logger.info(json.dumps(data_project_dict, indent=2))
+        
+        # Success message
+        stats_text = f"Loaded {len(df)} feature vectors from experiment {selected_uuid}"
+        
+        return scatter_fig, stats_text, data_project_dict, live_indices
+            
+    except Exception as e:
+        logger.error(f"Error loading experiment: {e}")
+        logger.error(traceback.format_exc())
+        return no_update, f"Error loading experiment: {str(e)}", data_project_dict, live_indices

--- a/src/callbacks/live_mode.py
+++ b/src/callbacks/live_mode.py
@@ -116,6 +116,7 @@ def update_model_dropdowns(dialog_open):
     Output("live-indices", "data", allow_duplicate=True),
     Output("model-loading-spinner", "style", allow_duplicate=True),
     Output("in-model-transition", "data", allow_duplicate=True),
+    Output("experiment-replay-controls", "style"),  # ADDED
     Input("live-model-continue", "n_clicks"),
     State("live-autoencoder-dropdown", "value"),
     State("live-dimred-dropdown", "value"),
@@ -220,6 +221,7 @@ def handle_model_continue(
         [],  # Clear indices
         spinner_style,  # Show the loading spinner
         True,  # Set transition state to True
+        {"display": "none"},  # Hide experiment replay controls - ADDED
     )
 
 
@@ -291,6 +293,7 @@ def toggle_continue_button(selected_autoencoder, selected_dimred):
     Output("live-indices", "data", allow_duplicate=True),
     Output("live-mode-canceled", "data", allow_duplicate=True),
     Output("selected-live-models", "data", allow_duplicate=True),
+    Output("experiment-replay-controls", "style", allow_duplicate=True),  # ADDED
     Input("go-live", "n_clicks"),
     State("selected-live-models", "data"),
     State("live-mode-canceled", "data"),
@@ -321,7 +324,8 @@ def toggle_controls(n_clicks, selected_models, mode_canceled):
             no_update,  # pause-button style
             no_update,  # live-indices data
             False,  # Reset the cancel flag
-            None,
+            None,  # selected-live-models data
+            no_update,  # experiment-replay-controls style - ADDED
         )
 
     # Check if continue was already clicked (selected_models is not None)
@@ -341,8 +345,8 @@ def toggle_controls(n_clicks, selected_models, mode_canceled):
 
         # Going back to offline mode
         return (
-            False,
-            False,
+            False,  # show-clusters value
+            False,  # show-feature-vectors value
             {},  # Show data selection controls
             {},  # Show dimension reduction controls
             {},  # Show clustering controls
@@ -367,13 +371,14 @@ def toggle_controls(n_clicks, selected_models, mode_canceled):
             [],  # Clear live indices
             False,  # Reset canceled flag
             None,  # Reset selected_models to None
+            {},  # Show experiment replay controls - ADDED
         )
 
     # First click or other odd clicks - going to live mode
     if n_clicks is not None and n_clicks % 2 == 1 and selected_models is not None:
         return (
-            False,
-            False,
+            False,  # show-clusters value
+            False,  # show-feature-vectors value
             {"display": "none"},  # Hide data selection controls
             {"display": "none"},  # Hide dimension reduction controls
             {"display": "none"},  # Hide clustering controls
@@ -400,6 +405,7 @@ def toggle_controls(n_clicks, selected_models, mode_canceled):
             [],  # Initialize empty live indices
             False,  # Reset canceled flag
             selected_models,  # Keep selected_models unchanged
+            {"display": "none"},  # Hide experiment replay controls - ADDED
         )
 
     raise PreventUpdate

--- a/src/callbacks/live_mode.py
+++ b/src/callbacks/live_mode.py
@@ -90,6 +90,7 @@ def update_model_dropdowns(dialog_open):
 
 
 
+
 @callback(
     Output("live-model-dialog", "is_open", allow_duplicate=True),
     Output("selected-live-models", "data"),
@@ -98,10 +99,16 @@ def update_model_dropdowns(dialog_open):
     Output("clustering-controls", "style"),
     Output("data-overview-card", "style"),
     Output("live-mode-models", "style"),
-    Output("live-mode-autoencoder-dropdown", "options"),
-    Output("live-mode-autoencoder-dropdown", "value"),
-    Output("live-mode-dimred-dropdown", "options"),
-    Output("live-mode-dimred-dropdown", "value"),
+    Output("live-mode-autoencoder-dropdown", "options", allow_duplicate=True),
+    Output("live-mode-autoencoder-dropdown", "value", allow_duplicate=True),
+    Output("live-mode-autoencoder-version-dropdown", "options", allow_duplicate=True),
+    Output("live-mode-autoencoder-version-dropdown", "value", allow_duplicate=True),
+    Output("live-mode-autoencoder-version-dropdown", "disabled", allow_duplicate=True),
+    Output("live-mode-dimred-dropdown", "options", allow_duplicate=True),
+    Output("live-mode-dimred-dropdown", "value", allow_duplicate=True),
+    Output("live-mode-dimred-version-dropdown", "options", allow_duplicate=True),
+    Output("live-mode-dimred-version-dropdown", "value", allow_duplicate=True),
+    Output("live-mode-dimred-version-dropdown", "disabled", allow_duplicate=True),
     Output("sidebar", "active_item"),
     Output("image-card", "style"),
     Output("scatter", "style"),
@@ -116,10 +123,12 @@ def update_model_dropdowns(dialog_open):
     Output("live-indices", "data", allow_duplicate=True),
     Output("model-loading-spinner", "style", allow_duplicate=True),
     Output("in-model-transition", "data", allow_duplicate=True),
-    Output("experiment-replay-controls", "style"),  # ADDED
+    Output("experiment-replay-controls", "style"),
     Input("live-model-continue", "n_clicks"),
     State("live-autoencoder-dropdown", "value"),
+    State("live-autoencoder-version-dropdown", "value"),
     State("live-dimred-dropdown", "value"),
+    State("live-dimred-version-dropdown", "value"),
     State("live-autoencoder-dropdown", "options"),
     State("live-dimred-dropdown", "options"),
     prevent_initial_call=True,
@@ -127,18 +136,13 @@ def update_model_dropdowns(dialog_open):
 def handle_model_continue(
     continue_clicks,
     selected_autoencoder,
+    selected_autoencoder_version,
     selected_dimred,
+    selected_dimred_version,
     autoencoder_options,
     dimred_options,
 ):
-    """
-    Handle the Continue button click in the model selection dialog.
-    This function:
-    1. Checks model compatibility
-    2. Stores models in Redis if compatible
-    3. Updates UI elements for Live Mode
-    4. Shows loading spinner
-    """
+    """Handle the Continue button click with version selection"""
     if not continue_clicks:
         raise PreventUpdate
 
@@ -149,29 +153,35 @@ def handle_model_continue(
         logger.warning(
             f"Incompatible models selected: {selected_autoencoder}, {selected_dimred}"
         )
-        # Prevent dialog from closing
         return no_update
 
-    # Store models in Redis
+    # Store models with versions in Redis
     try:
-        # Store autoencoder model
-        logger.info(f"Storing autoencoder model from dialog: {selected_autoencoder}")
-        redis_model_store.store_autoencoder_model(selected_autoencoder)
+        # Create model identifiers with versions
+        autoencoder_id = f"{selected_autoencoder}:{selected_autoencoder_version}"
+        dimred_id = f"{selected_dimred}:{selected_dimred_version}"
+        
+        logger.info(f"Storing autoencoder model from dialog: {autoencoder_id}")
+        redis_model_store.store_autoencoder_model(autoencoder_id)
 
-        # Store dimension reduction model
-        logger.info(f"Storing dimension reduction model from dialog: {selected_dimred}")
-        redis_model_store.store_dimred_model(selected_dimred)
+        logger.info(f"Storing dimension reduction model from dialog: {dimred_id}")
+        redis_model_store.store_dimred_model(dimred_id)
     except Exception as e:
         logger.error(f"Error storing models in Redis: {e}")
         return no_update
 
-    # Models are compatible and stored in Redis, proceed with closing dialog and transition
     selected_models = {
         "autoencoder": selected_autoencoder,
+        "autoencoder_version": selected_autoencoder_version,
         "dimred": selected_dimred,
+        "dimred_version": selected_dimred_version,
     }
 
-    # Show loading spinner and set transition state to True
+    # Get version options for sidebar
+    autoencoder_versions = mlflow_client.get_model_versions(selected_autoencoder)
+    dimred_versions = mlflow_client.get_model_versions(selected_dimred)
+
+    # Show loading spinner
     spinner_style = {
         "position": "fixed",
         "top": 0,
@@ -180,10 +190,9 @@ def handle_model_continue(
         "height": "100%",
         "backgroundColor": "rgba(0, 0, 0, 0.7)",
         "zIndex": 9998,
-        "display": "block",  # Show the spinner
+        "display": "block",
     }
 
-    # Transition to live mode UI
     return (
         False,  # Close dialog
         selected_models,  # Save selected models
@@ -192,10 +201,16 @@ def handle_model_continue(
         {"display": "none"},  # Hide clustering controls
         {"display": "none"},  # Hide data overview card
         {},  # Show live mode models section
-        autoencoder_options,  # Copy options from dialog to sidebar
-        selected_autoencoder,  # Set selected autoencoder
-        dimred_options,  # Copy options from dialog to sidebar
-        selected_dimred,  # Set selected dimension reduction model
+        autoencoder_options,  # Copy options to sidebar
+        selected_autoencoder,  # Set selected autoencoder name
+        autoencoder_versions,  # Set autoencoder version options
+        selected_autoencoder_version,  # Set selected autoencoder version
+        False,  # Enable autoencoder version dropdown
+        dimred_options,  # Copy options to sidebar
+        selected_dimred,  # Set selected dimred name
+        dimred_versions,  # Set dimred version options
+        selected_dimred_version,  # Set selected dimred version
+        False,  # Enable dimred version dropdown
         ["item-1"],  # Active sidebar item
         {"width": "100%", "height": "85vh"},  # Image card style
         {"height": "65vh"},  # Scatter style
@@ -214,16 +229,15 @@ def handle_model_continue(
             "font-size": "1.5rem",
             "padding": "5px",
         },
-        plot_empty_scatter(),  # Clear scatter when continuing
-        plot_empty_heatmap(),  # Clear heatmap when continuing
-        "Number of images selected: 0",  # Reset stats text
+        plot_empty_scatter(),  # Clear scatter
+        plot_empty_heatmap(),  # Clear heatmap
+        "Number of images selected: 0",  # Reset stats
         {},  # Clear buffer
         [],  # Clear indices
-        spinner_style,  # Show the loading spinner
-        True,  # Set transition state to True
-        {"display": "none"},  # Hide experiment replay controls - ADDED
+        spinner_style,  # Show loading spinner
+        True,  # Set transition state
+        {"display": "none"},  # Hide experiment replay controls
     )
-
 
 @callback(
     Output("live-model-dialog", "is_open", allow_duplicate=True),
@@ -245,21 +259,26 @@ def handle_model_cancel(cancel_clicks, go_live_clicks):
     raise PreventUpdate
 
 
+# Replace the existing toggle_continue_button callback in live_mode.py
+
 @callback(
     Output("live-model-continue", "disabled"),
     Output("live-model-continue", "color", allow_duplicate=True),
     Output("live-model-continue", "children", allow_duplicate=True),
     Input("live-autoencoder-dropdown", "value"),
     Input("live-dimred-dropdown", "value"),
-    prevent_initial_call=True,  # Add this to prevent initial call
+    Input("live-autoencoder-version-dropdown", "value"),
+    Input("live-dimred-version-dropdown", "value"),
+    prevent_initial_call=True,
 )
-def toggle_continue_button(selected_autoencoder, selected_dimred):
+def toggle_continue_button(selected_autoencoder, selected_dimred, auto_version, dimred_version):
     """
-    Disable the continue button if models are not selected or are incompatible
+    Disable the continue button if models or versions are not selected or are incompatible
     Also update the button color and text to indicate state
     """
-    # First check if either model is not selected
-    if selected_autoencoder is None or selected_dimred is None:
+    # Check if any required field is not selected
+    if (selected_autoencoder is None or selected_dimred is None or 
+        auto_version is None or dimred_version is None):
         return True, "secondary", "Continue"  # Disabled with neutral color
 
     # Check if models are compatible
@@ -273,7 +292,6 @@ def toggle_continue_button(selected_autoencoder, selected_dimred):
     else:
         # Models are incompatible - disable with danger color
         return True, "danger", "Incompatible Models"
-
 
 @callback(
     Output("show-clusters", "value", allow_duplicate=True),
@@ -494,16 +512,19 @@ def update_data_project_dict(n_clicks, selected_models):
     Output("buffer", "data", allow_duplicate=True),
     Input("update-live-models-button", "n_clicks"),
     State("live-mode-autoencoder-dropdown", "value"),
+    State("live-mode-autoencoder-version-dropdown", "value"),  # ADDED
     State("live-mode-dimred-dropdown", "value"),
+    State("live-mode-dimred-version-dropdown", "value"),  # ADDED
     State({"base_id": "file-manager", "name": "data-project-dict"}, "data"),
     prevent_initial_call=True,
 )
-def update_live_models(n_clicks, autoencoder_model, dimred_model, data_project_dict):
+def update_live_models(n_clicks, autoencoder_model, autoencoder_version, 
+                       dimred_model, dimred_version, data_project_dict):
     """
     Update the selected models when the sidebar update button is clicked.
     This function:
     1. Checks model compatibility
-    2. Stores models in Redis if compatible
+    2. Stores models with versions in Redis if compatible
     3. Updates data project dictionary
     4. Resets visualizations
     5. Shows loading spinner
@@ -511,7 +532,7 @@ def update_live_models(n_clicks, autoencoder_model, dimred_model, data_project_d
     if n_clicks is None:
         raise PreventUpdate
 
-    # Check model compatibility
+    # Check model compatibility (names only, since dimensions don't change between versions)
     if not mlflow_client.check_model_compatibility(autoencoder_model, dimred_model):
         logger.warning(
             f"Incompatible models selected: {autoencoder_model}, {dimred_model}"
@@ -530,15 +551,17 @@ def update_live_models(n_clicks, autoencoder_model, dimred_model, data_project_d
             no_update,  # buffer.data
         )
 
+    # Create model identifiers with versions
+    autoencoder_id = f"{autoencoder_model}:{autoencoder_version}"
+    dimred_id = f"{dimred_model}:{dimred_version}"
+
     # Store models in Redis
     try:
-        # Store autoencoder model
-        logger.info(f"Storing autoencoder model from sidebar: {autoencoder_model}")
-        redis_model_store.store_autoencoder_model(autoencoder_model)
+        logger.info(f"Storing autoencoder model from sidebar: {autoencoder_id}")
+        redis_model_store.store_autoencoder_model(autoencoder_id)
 
-        # Store dimension reduction model
-        logger.info(f"Storing dimension reduction model from sidebar: {dimred_model}")
-        redis_model_store.store_dimred_model(dimred_model)
+        logger.info(f"Storing dimension reduction model from sidebar: {dimred_id}")
+        redis_model_store.store_dimred_model(dimred_id)
     except Exception as e:
         logger.error(f"Error storing models in Redis: {e}")
         return (
@@ -555,8 +578,13 @@ def update_live_models(n_clicks, autoencoder_model, dimred_model, data_project_d
             no_update,
         )
 
-    # Update the selected models
-    selected_models = {"autoencoder": autoencoder_model, "dimred": dimred_model}
+    # Update the selected models (include versions)
+    selected_models = {
+        "autoencoder": autoencoder_model,
+        "autoencoder_version": autoencoder_version,
+        "dimred": dimred_model,
+        "dimred_version": dimred_version
+    }
 
     # Update data project dict with new models
     data_project_dict = {
@@ -611,19 +639,25 @@ def update_live_models(n_clicks, autoencoder_model, dimred_model, data_project_d
     Output("update-live-models-button", "color", allow_duplicate=True),
     Output("update-live-models-button", "children", allow_duplicate=True),
     Input("live-mode-autoencoder-dropdown", "value"),
+    Input("live-mode-autoencoder-version-dropdown", "value"),  # ADDED
     Input("live-mode-dimred-dropdown", "value"),
+    Input("live-mode-dimred-version-dropdown", "value"),  # ADDED
     State("selected-live-models", "data"),
     prevent_initial_call=True,
 )
-def reset_update_button(autoencoder_model, dimred_model, selected_models):
+def reset_update_button(autoencoder_model, autoencoder_version, 
+                        dimred_model, dimred_version, selected_models):
     """
-    Reset the update button color when dropdowns change and check model compatibility
+    Reset the update button color when dropdowns change and check model compatibility.
+    Now also checks if versions have changed.
     """
-    # If no models are selected yet or either dropdown is empty
-    if selected_models is None or autoencoder_model is None or dimred_model is None:
+    # If no models are selected yet or any dropdown is empty
+    if (selected_models is None or 
+        autoencoder_model is None or dimred_model is None or
+        autoencoder_version is None or dimred_version is None):
         return True, "secondary", "Update Models"  # Disabled, secondary color
 
-    # Check if models are compatible using the shared compatibility check function
+    # Check if models are compatible (names only)
     is_compatible = mlflow_client.check_model_compatibility(
         autoencoder_model, dimred_model
     )
@@ -632,10 +666,13 @@ def reset_update_button(autoencoder_model, dimred_model, selected_models):
         # Models are incompatible - disable button with danger color
         return True, "danger", "Incompatible Models"
 
-    # Check if the current selection is different from what's already selected
-    models_changed = autoencoder_model != selected_models.get(
-        "autoencoder"
-    ) or dimred_model != selected_models.get("dimred")
+    # Check if EITHER name OR version changed
+    models_changed = (
+        autoencoder_model != selected_models.get("autoencoder") or
+        autoencoder_version != selected_models.get("autoencoder_version") or
+        dimred_model != selected_models.get("dimred") or
+        dimred_version != selected_models.get("dimred_version")
+    )
 
     if models_changed:
         # Models are compatible and changed - enable button with primary color
@@ -887,3 +924,96 @@ def force_data_reset(n_clicks):
         # Reset for both entering and exiting live mode
         return 0, 0, None
     raise PreventUpdate
+
+# Dialog version dropdowns
+@callback(
+    Output("live-autoencoder-version-dropdown", "options"),
+    Output("live-autoencoder-version-dropdown", "disabled"),
+    Output("live-autoencoder-version-dropdown", "value"),
+    Input("live-autoencoder-dropdown", "value"),
+    prevent_initial_call=True,
+)
+def update_dialog_autoencoder_versions(selected_model):
+    """Load version options when autoencoder model name is selected in dialog"""
+    if not selected_model:
+        return [], True, None
+    
+    try:
+        versions = mlflow_client.get_model_versions(selected_model)
+        if versions:
+            # Default to latest version
+            return versions, False, versions[0]["value"]
+        return [], True, None
+    except Exception as e:
+        logger.error(f"Error loading autoencoder versions: {e}")
+        return [], True, None
+
+
+@callback(
+    Output("live-dimred-version-dropdown", "options"),
+    Output("live-dimred-version-dropdown", "disabled"),
+    Output("live-dimred-version-dropdown", "value"),
+    Input("live-dimred-dropdown", "value"),
+    prevent_initial_call=True,
+)
+def update_dialog_dimred_versions(selected_model):
+    """Load version options when dimred model name is selected in dialog"""
+    if not selected_model:
+        return [], True, None
+    
+    try:
+        versions = mlflow_client.get_model_versions(selected_model)
+        if versions:
+            # Default to latest version
+            return versions, False, versions[0]["value"]
+        return [], True, None
+    except Exception as e:
+        logger.error(f"Error loading dimred versions: {e}")
+        return [], True, None
+
+
+# Sidebar version dropdowns
+@callback(
+    Output("live-mode-autoencoder-version-dropdown", "options"),
+    Output("live-mode-autoencoder-version-dropdown", "disabled"),
+    Output("live-mode-autoencoder-version-dropdown", "value"),
+    Input("live-mode-autoencoder-dropdown", "value"),
+    prevent_initial_call=True,
+)
+def update_sidebar_autoencoder_versions(selected_model):
+    """Load version options when autoencoder model name is selected in sidebar"""
+    if not selected_model:
+        return [], True, None
+    
+    try:
+        versions = mlflow_client.get_model_versions(selected_model)
+        if versions:
+            # Default to latest version
+            return versions, False, versions[0]["value"]
+        return [], True, None
+    except Exception as e:
+        logger.error(f"Error loading autoencoder versions: {e}")
+        return [], True, None
+
+
+@callback(
+    Output("live-mode-dimred-version-dropdown", "options"),
+    Output("live-mode-dimred-version-dropdown", "disabled"),
+    Output("live-mode-dimred-version-dropdown", "value"),
+    Input("live-mode-dimred-dropdown", "value"),
+    prevent_initial_call=True,
+)
+def update_sidebar_dimred_versions(selected_model):
+    """Load version options when dimred model name is selected in sidebar"""
+    if not selected_model:
+        return [], True, None
+    
+    try:
+        versions = mlflow_client.get_model_versions(selected_model)
+        if versions:
+            # Default to latest version
+            return versions, False, versions[0]["value"]
+        return [], True, None
+    except Exception as e:
+        logger.error(f"Error loading dimred versions: {e}")
+        return [], True, None

--- a/src/components/main_display.py
+++ b/src/components/main_display.py
@@ -9,8 +9,7 @@ from dash_iconify import DashIconify
 from ..utils.plot_utils import draw_rows, plot_empty_heatmap, plot_empty_scatter
 from .model_selection_dialog import create_model_selection_dialog
 
-logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("lse.main_display")
 
 NUM_IMGS_OVERVIEW = 6
 WEBSOCKET_URL = os.getenv("WEBSOCKET_URL", "ws://localhost:8765/lse")

--- a/src/components/main_display.py
+++ b/src/components/main_display.py
@@ -217,6 +217,7 @@ def main_display():
             create_model_selection_dialog(),
             dcc.Store(id="selected-live-models", data=None),
             dcc.Store(id="buffer", data={}),
+            dcc.Store(id="replay-buffer", data={}),
             dcc.Interval(id="buffer-debounce", interval=100, n_intervals=0),  # 100ms
             dcc.Store(id="live-indices", data=[]),
             WebSocket(id="ws-live", url=WEBSOCKET_URL),

--- a/src/components/model_selection_dialog.py
+++ b/src/components/model_selection_dialog.py
@@ -15,6 +15,14 @@ def create_model_selection_dialog():
                             html.P(
                                 "Please select models to use for processing live data stream:"
                             ),
+                            # NEW: Experiment Name Input
+                            html.H6("Experiment Name:"),
+                            dbc.Input(
+                                id="live-experiment-name-input",
+                                type="text",
+                                placeholder="Enter experiment name...",
+                                className="mb-3",
+                            ),
                             html.H6("Autoencoder Model:"),
                             dbc.Row(
                                 [

--- a/src/components/model_selection_dialog.py
+++ b/src/components/model_selection_dialog.py
@@ -16,19 +16,53 @@ def create_model_selection_dialog():
                                 "Please select models to use for processing live data stream:"
                             ),
                             html.H6("Autoencoder Model:"),
-                            dbc.Select(
-                                id="live-autoencoder-dropdown",
-                                options=[],  # Will be populated by callback
-                                value=None,
-                                placeholder="Select an autoencoder model...",
+                            dbc.Row(
+                                [
+                                    dbc.Col(
+                                        dbc.Select(
+                                            id="live-autoencoder-dropdown",
+                                            options=[],
+                                            value=None,
+                                            placeholder="Select model name...",
+                                        ),
+                                        width=7,
+                                    ),
+                                    dbc.Col(
+                                        dbc.Select(
+                                            id="live-autoencoder-version-dropdown",
+                                            options=[],
+                                            value=None,
+                                            placeholder="Select version...",
+                                            disabled=True,
+                                        ),
+                                        width=5,
+                                    ),
+                                ],
                                 className="mb-3",
                             ),
                             html.H6("Dimension Reduction Model:"),
-                            dbc.Select(
-                                id="live-dimred-dropdown",
-                                options=[],  # Will be populated by callback
-                                value=None,
-                                placeholder="Select a dimension reduction model...",
+                            dbc.Row(
+                                [
+                                    dbc.Col(
+                                        dbc.Select(
+                                            id="live-dimred-dropdown",
+                                            options=[],
+                                            value=None,
+                                            placeholder="Select model name...",
+                                        ),
+                                        width=7,
+                                    ),
+                                    dbc.Col(
+                                        dbc.Select(
+                                            id="live-dimred-version-dropdown",
+                                            options=[],
+                                            value=None,
+                                            placeholder="Select version...",
+                                            disabled=True,
+                                        ),
+                                        width=5,
+                                    ),
+                                ],
                             ),
                         ]
                     ),
@@ -50,8 +84,8 @@ def create_model_selection_dialog():
                 ],
                 id="live-model-dialog",
                 is_open=False,
-                backdrop="static",  # Modal cannot be closed by clicking outside
-                keyboard=False,     # Modal cannot be closed by pressing escape
+                backdrop="static",
+                keyboard=False,
                 centered=True,
             ),
         ]

--- a/src/components/sidebar.py
+++ b/src/components/sidebar.py
@@ -218,7 +218,42 @@ def sidebar(file_explorer, job_manager, clustering_job_manager):
                             id="experiment-replay-controls",
                             title="Experiment Replay",
                             children=[
-                                # First create the label and dropdown in a standard ControlItem
+                                # First dropdown for daily container selection
+                                ControlItem(
+                                    "Daily Container",
+                                    "daily-container-title",
+                                    html.Div([
+                                        dbc.Row([
+                                            dbc.Col(
+                                                dbc.Select(
+                                                    id="daily-container-dropdown",
+                                                    options=[],
+                                                    value=None,
+                                                    placeholder="Select a daily container",
+                                                ),
+                                                width=10,
+                                            ),
+                                            dbc.Col(
+                                                dbc.Button(
+                                                    DashIconify(
+                                                        icon="tabler:refresh",
+                                                        width=18,
+                                                        height=18,
+                                                    ),
+                                                    id="refresh-daily-containers",
+                                                    color="light",
+                                                    size="sm",
+                                                    className="rounded-circle",
+                                                    style={"aspectRatio": "1 / 1"},
+                                                ),
+                                                width=1,
+                                                style={"padding-left": "0"},
+                                            ),
+                                        ], className="align-items-center"),
+                                    ]),
+                                ),
+                                html.P(),
+                                # Second dropdown for UUID selection within the selected container
                                 ControlItem(
                                     "Experiment UUID",
                                     "experiment-uuid-title",

--- a/src/components/sidebar.py
+++ b/src/components/sidebar.py
@@ -78,56 +78,6 @@ def sidebar(file_explorer, job_manager, clustering_job_manager):
                                 ),
                             ],
                         ),
-                        # Option 1: Modify the experiment-replay-controls section to use a simpler structure
-                        dbc.AccordionItem(
-                            id="experiment-replay-controls",
-                            title="Experiment Replay",
-                            children=[
-                                # First create the label and dropdown in a standard ControlItem
-                                ControlItem(
-                                    "Experiment UUID",
-                                    "experiment-uuid-title",
-                                    html.Div([
-                                        dbc.Row([
-                                            dbc.Col(
-                                                dbc.Select(
-                                                    id="experiment-uuid-dropdown",
-                                                    options=[],
-                                                    value=None,
-                                                    placeholder="Select an experiment UUID",
-                                                ),
-                                                width=10,
-                                            ),
-                                            dbc.Col(
-                                                dbc.Button(
-                                                    DashIconify(
-                                                        icon="tabler:refresh",
-                                                        width=18,
-                                                        height=18,
-                                                    ),
-                                                    id="refresh-experiment-uuids",
-                                                    color="light",
-                                                    size="sm",
-                                                    className="rounded-circle",
-                                                    style={"aspectRatio": "1 / 1"},
-                                                ),
-                                                width=1,
-                                                style={"padding-left": "0"},
-                                            ),
-                                        ], className="align-items-center"),  # Add this class to align row items
-                                    ]),
-                                ),
-                                # Then add the button separately below
-                                html.Div(style={"height": "20px"}),
-                                dbc.Button(
-                                    "Load Experiment",
-                                    id="load-experiment-button",
-                                    color="primary",
-                                    className="w-100",
-                                    disabled=True,
-                                ),
-                            ],
-                        ),
                         dbc.AccordionItem(
                             id="live-mode-models",
                             title="Live Mode Models",
@@ -262,6 +212,72 @@ def sidebar(file_explorer, job_manager, clustering_job_manager):
                                 ),
                             ],
                             title="Clustering",
+                        ),
+                        # Moved experiment replay section after clustering
+                        dbc.AccordionItem(
+                            id="experiment-replay-controls",
+                            title="Experiment Replay",
+                            children=[
+                                # First create the label and dropdown in a standard ControlItem
+                                ControlItem(
+                                    "Experiment UUID",
+                                    "experiment-uuid-title",
+                                    html.Div([
+                                        dbc.Row([
+                                            dbc.Col(
+                                                dbc.Select(
+                                                    id="experiment-uuid-dropdown",
+                                                    options=[],
+                                                    value=None,
+                                                    placeholder="Select an experiment UUID",
+                                                ),
+                                                width=10,
+                                            ),
+                                            dbc.Col(
+                                                dbc.Button(
+                                                    DashIconify(
+                                                        icon="tabler:refresh",
+                                                        width=18,
+                                                        height=18,
+                                                    ),
+                                                    id="refresh-experiment-uuids",
+                                                    color="light",
+                                                    size="sm",
+                                                    className="rounded-circle",
+                                                    style={"aspectRatio": "1 / 1"},
+                                                ),
+                                                width=1,
+                                                style={"padding-left": "0"},
+                                            ),
+                                        ], className="align-items-center"),  # Add this class to align row items
+                                    ]),
+                                ),
+                                html.P(),
+                                # Add data percentage slider
+                                ControlItem(
+                                    "Data Percentage",
+                                    "replay-data-percentage-title",
+                                    dcc.RangeSlider(
+                                        id="replay-data-percentage",
+                                        min=0,
+                                        max=100,
+                                        tooltip={
+                                            "placement": "bottom",
+                                            "always_visible": True,
+                                        },
+                                        value=[0, 100],
+                                    ),
+                                ),
+                                # Then add the button separately below
+                                html.Div(style={"height": "20px"}),
+                                dbc.Button(
+                                    "Load Experiment",
+                                    id="load-experiment-button",
+                                    color="primary",
+                                    className="w-100",
+                                    disabled=True,
+                                ),
+                            ],
                         ),
                     ],
                 ),

--- a/src/components/sidebar.py
+++ b/src/components/sidebar.py
@@ -78,6 +78,56 @@ def sidebar(file_explorer, job_manager, clustering_job_manager):
                                 ),
                             ],
                         ),
+                        # Option 1: Modify the experiment-replay-controls section to use a simpler structure
+                        dbc.AccordionItem(
+                            id="experiment-replay-controls",
+                            title="Experiment Replay",
+                            children=[
+                                # First create the label and dropdown in a standard ControlItem
+                                ControlItem(
+                                    "Experiment UUID",
+                                    "experiment-uuid-title",
+                                    html.Div([
+                                        dbc.Row([
+                                            dbc.Col(
+                                                dbc.Select(
+                                                    id="experiment-uuid-dropdown",
+                                                    options=[],
+                                                    value=None,
+                                                    placeholder="Select an experiment UUID",
+                                                ),
+                                                width=10,
+                                            ),
+                                            dbc.Col(
+                                                dbc.Button(
+                                                    DashIconify(
+                                                        icon="tabler:refresh",
+                                                        width=18,
+                                                        height=18,
+                                                    ),
+                                                    id="refresh-experiment-uuids",
+                                                    color="light",
+                                                    size="sm",
+                                                    className="rounded-circle",
+                                                    style={"aspectRatio": "1 / 1"},
+                                                ),
+                                                width=1,
+                                                style={"padding-left": "0"},
+                                            ),
+                                        ], className="align-items-center"),  # Add this class to align row items
+                                    ]),
+                                ),
+                                # Then add the button separately below
+                                html.Div(style={"height": "20px"}),
+                                dbc.Button(
+                                    "Load Experiment",
+                                    id="load-experiment-button",
+                                    color="primary",
+                                    className="w-100",
+                                    disabled=True,
+                                ),
+                            ],
+                        ),
                         dbc.AccordionItem(
                             id="live-mode-models",
                             title="Live Mode Models",

--- a/src/components/sidebar.py
+++ b/src/components/sidebar.py
@@ -82,6 +82,30 @@ def sidebar(file_explorer, job_manager, clustering_job_manager):
                             id="live-mode-models",
                             title="Live Mode Models",
                             children=[
+                                # NEW: Add experiment name display at the top
+                                html.Div(
+                                    id="live-experiment-name-display",
+                                    children=[
+                                        html.Div(
+                                            [
+                                                html.Strong("Experiment: ", style={"color": "#00313C"}),
+                                                html.Span(
+                                                    id="live-experiment-name-text",
+                                                    children="",
+                                                    style={"color": "#D57800", "fontWeight": "500"}
+                                                ),
+                                            ],
+                                            style={
+                                                "padding": "10px",
+                                                "backgroundColor": "#f8f9fa",
+                                                "borderRadius": "5px",
+                                                "marginBottom": "15px",
+                                                "border": "1px solid #dee2e6"
+                                            }
+                                        ),
+                                    ],
+                                    style={"display": "none"}  # Hidden by default, shown in live mode
+                                ),
                                 ControlItem(
                                     "Autoencoder Model",
                                     "live-mode-autoencoder-title",
@@ -263,6 +287,41 @@ def sidebar(file_explorer, job_manager, clustering_job_manager):
                                                         height=18,
                                                     ),
                                                     id="refresh-daily-containers",
+                                                    color="light",
+                                                    size="sm",
+                                                    className="rounded-circle",
+                                                    style={"aspectRatio": "1 / 1"},
+                                                ),
+                                                width=1,
+                                                style={"padding-left": "0"},
+                                            ),
+                                        ], className="align-items-center"),
+                                    ]),
+                                ),
+                                html.P(),
+                                # NEW: Experiment Name dropdown
+                                ControlItem(
+                                    "Experiment Name",
+                                    "experiment-name-title",
+                                    html.Div([
+                                        dbc.Row([
+                                            dbc.Col(
+                                                dbc.Select(
+                                                    id="experiment-name-dropdown",
+                                                    options=[],
+                                                    value=None,
+                                                    placeholder="Select an experiment name",
+                                                ),
+                                                width=10,
+                                            ),
+                                            dbc.Col(
+                                                dbc.Button(
+                                                    DashIconify(
+                                                        icon="tabler:refresh",
+                                                        width=18,
+                                                        height=18,
+                                                    ),
+                                                    id="refresh-experiment-names",
                                                     color="light",
                                                     size="sm",
                                                     className="rounded-circle",

--- a/src/components/sidebar.py
+++ b/src/components/sidebar.py
@@ -88,7 +88,18 @@ def sidebar(file_explorer, job_manager, clustering_job_manager):
                                     dbc.Select(
                                         id="live-mode-autoencoder-dropdown",
                                         options=[],
-                                        placeholder="Select an autoencoder model...",
+                                        placeholder="Select model name...",
+                                    ),
+                                ),
+                                html.P(),
+                                ControlItem(
+                                    "Autoencoder Version",
+                                    "live-mode-autoencoder-version-title",
+                                    dbc.Select(
+                                        id="live-mode-autoencoder-version-dropdown",
+                                        options=[],
+                                        placeholder="Select version...",
+                                        disabled=True,
                                     ),
                                 ),
                                 html.P(),
@@ -98,7 +109,18 @@ def sidebar(file_explorer, job_manager, clustering_job_manager):
                                     dbc.Select(
                                         id="live-mode-dimred-dropdown",
                                         options=[],
-                                        placeholder="Select a dimension reduction model...",
+                                        placeholder="Select model name...",
+                                    ),
+                                ),
+                                html.P(),
+                                ControlItem(
+                                    "Dimension Reduction Version",
+                                    "live-mode-dimred-version-title",
+                                    dbc.Select(
+                                        id="live-mode-dimred-version-dropdown",
+                                        options=[],
+                                        placeholder="Select version...",
+                                        disabled=True,
                                     ),
                                 ),
                                 html.P(),

--- a/src/components/sidebar.py
+++ b/src/components/sidebar.py
@@ -296,6 +296,8 @@ def sidebar(file_explorer, job_manager, clustering_job_manager):
                                         id="replay-data-range",
                                         min=0,
                                         max=100,
+                                        step=1,  # Add this to enforce integer steps
+                                        marks={i: str(i) for i in range(0, 101, 20)},  # Add default marks at intervals of 20
                                         tooltip={
                                             "placement": "bottom",
                                             "always_visible": True,

--- a/src/components/sidebar.py
+++ b/src/components/sidebar.py
@@ -288,12 +288,12 @@ def sidebar(file_explorer, job_manager, clustering_job_manager):
                                     ]),
                                 ),
                                 html.P(),
-                                # Add data percentage slider
+                                # Change from Data Percentage to Data Range
                                 ControlItem(
-                                    "Data Percentage",
-                                    "replay-data-percentage-title",
+                                    "Data Range",
+                                    "replay-data-range-title",
                                     dcc.RangeSlider(
-                                        id="replay-data-percentage",
+                                        id="replay-data-range",
                                         min=0,
                                         max=100,
                                         tooltip={

--- a/src/test/test_model_callbacks.py
+++ b/src/test/test_model_callbacks.py
@@ -24,6 +24,7 @@ class TestModelCallbacks:
         """Test handling continue button with compatible models"""
         # Setup
         continue_clicks = 1
+        experiment_name = "test_experiment"  # ADD THIS LINE
         selected_auto = "compatible_auto"
         selected_dimred = "compatible_dimred"
         auto_version = "3"
@@ -48,6 +49,7 @@ class TestModelCallbacks:
             # Execute
             results = handle_model_continue(
                 continue_clicks,
+                experiment_name,  # ADD THIS LINE
                 selected_auto,
                 auto_version,
                 selected_dimred,
@@ -62,6 +64,7 @@ class TestModelCallbacks:
         
         mock_redis_store.store_autoencoder_model.assert_called_once_with(expected_auto)
         mock_redis_store.store_dimred_model.assert_called_once_with(expected_dimred)
+        mock_redis_store.store_experiment_name.assert_called_once_with(experiment_name)  # ADD THIS LINE
         
         # Verify dialog closed (first result should be False)
         assert results[0] is False
@@ -72,6 +75,7 @@ class TestModelCallbacks:
         assert selected_models["autoencoder_version"] == auto_version
         assert selected_models["dimred"] == selected_dimred
         assert selected_models["dimred_version"] == dimred_version
+        assert selected_models["experiment_name"] == experiment_name  # ADD THIS LINE
 
     def test_handle_model_continue_incompatible(
         self, mock_redis_store, mock_live_mode_mlflow_client
@@ -79,6 +83,7 @@ class TestModelCallbacks:
         """Test handling continue button with incompatible models"""
         # Setup
         continue_clicks = 1
+        experiment_name = "test_experiment"  # ADD THIS LINE
         selected_auto = "incompatible"
         selected_dimred = "compatible_dimred"
         auto_version = "1"
@@ -92,6 +97,7 @@ class TestModelCallbacks:
         # Execute
         result = handle_model_continue(
             continue_clicks,
+            experiment_name,  # ADD THIS LINE
             selected_auto,
             auto_version,
             selected_dimred,
@@ -103,6 +109,7 @@ class TestModelCallbacks:
         # Verify Redis calls were not made
         mock_redis_store.store_autoencoder_model.assert_not_called()
         mock_redis_store.store_dimred_model.assert_not_called()
+        mock_redis_store.store_experiment_name.assert_not_called()  # ADD THIS LINE
 
     def test_update_live_models(self, mock_redis_store, mock_live_mode_mlflow_client):
         """Test updating models from sidebar"""

--- a/src/test/test_model_callbacks.py
+++ b/src/test/test_model_callbacks.py
@@ -26,11 +26,18 @@ class TestModelCallbacks:
         continue_clicks = 1
         selected_auto = "compatible_auto"
         selected_dimred = "compatible_dimred"
+        auto_version = "3"
+        dimred_version = "2"
         auto_options = [{"label": "Auto1", "value": "compatible_auto"}]
         dimred_options = [{"label": "Dimred1", "value": "compatible_dimred"}]
 
         # Configure compatibility check
         mock_live_mode_mlflow_client.check_model_compatibility.return_value = True
+        
+        # Mock get_model_versions to return version options
+        mock_live_mode_mlflow_client.get_model_versions.return_value = [
+            {"label": "Version 3", "value": "3"}
+        ]
 
         # Mock plot functions to avoid errors
         with (
@@ -42,21 +49,29 @@ class TestModelCallbacks:
             results = handle_model_continue(
                 continue_clicks,
                 selected_auto,
+                auto_version,
                 selected_dimred,
+                dimred_version,
                 auto_options,
                 dimred_options,
             )
 
-        # Verify
-        assert results[0] is False  # Dialog should close
-        assert results[1] == {
-            "autoencoder": selected_auto,
-            "dimred": selected_dimred,
-        }  # Models stored
-
-        # Verify Redis calls
-        mock_redis_store.store_autoencoder_model.assert_called_once_with(selected_auto)
-        mock_redis_store.store_dimred_model.assert_called_once_with(selected_dimred)
+        # Main verification: Redis calls with version identifiers
+        expected_auto = f"{selected_auto}:{auto_version}"
+        expected_dimred = f"{selected_dimred}:{dimred_version}"
+        
+        mock_redis_store.store_autoencoder_model.assert_called_once_with(expected_auto)
+        mock_redis_store.store_dimred_model.assert_called_once_with(expected_dimred)
+        
+        # Verify dialog closed (first result should be False)
+        assert results[0] is False
+        
+        # Verify selected_models dict is at index 1 with versions
+        selected_models = results[1]
+        assert selected_models["autoencoder"] == selected_auto
+        assert selected_models["autoencoder_version"] == auto_version
+        assert selected_models["dimred"] == selected_dimred
+        assert selected_models["dimred_version"] == dimred_version
 
     def test_handle_model_continue_incompatible(
         self, mock_redis_store, mock_live_mode_mlflow_client
@@ -66,6 +81,8 @@ class TestModelCallbacks:
         continue_clicks = 1
         selected_auto = "incompatible"
         selected_dimred = "compatible_dimred"
+        auto_version = "1"
+        dimred_version = "1"
         auto_options = [{"label": "Auto1", "value": "incompatible"}]
         dimred_options = [{"label": "Dimred1", "value": "compatible_dimred"}]
 
@@ -73,11 +90,12 @@ class TestModelCallbacks:
         mock_live_mode_mlflow_client.check_model_compatibility.return_value = False
 
         # Execute
-        # The implementation doesn't raise PreventUpdate, so we just call it normally
         result = handle_model_continue(
             continue_clicks,
             selected_auto,
+            auto_version,
             selected_dimred,
+            dimred_version,
             auto_options,
             dimred_options,
         )
@@ -92,6 +110,8 @@ class TestModelCallbacks:
         n_clicks = 1
         autoencoder = "test_autoencoder"
         dimred = "test_dimred"
+        auto_version = "5"
+        dimred_version = "3"
         data_project_dict = {"root_uri": "", "datasets": []}
 
         # Configure compatibility check
@@ -105,23 +125,27 @@ class TestModelCallbacks:
 
             # Execute
             results = update_live_models(
-                n_clicks, autoencoder, dimred, data_project_dict
+                n_clicks, autoencoder, auto_version, dimred, dimred_version, data_project_dict
             )
 
-        # Verify
-        assert results[0] == {
-            "autoencoder": autoencoder,
-            "dimred": dimred,
-        }  # Selected models
-        assert "live_models" in results[1]  # Updated data project dict
-        assert results[1]["live_models"] == {
-            "autoencoder": autoencoder,
-            "dimred": dimred,
-        }
-
-        # Verify Redis calls
-        mock_redis_store.store_autoencoder_model.assert_called_once_with(autoencoder)
-        mock_redis_store.store_dimred_model.assert_called_once_with(dimred)
+        # Main verification: Redis calls with version identifiers
+        expected_auto = f"{autoencoder}:{auto_version}"
+        expected_dimred = f"{dimred}:{dimred_version}"
+        
+        mock_redis_store.store_autoencoder_model.assert_called_once_with(expected_auto)
+        mock_redis_store.store_dimred_model.assert_called_once_with(expected_dimred)
+        
+        # Verify selected_models is at index 0 with versions
+        selected_models = results[0]
+        assert selected_models["autoencoder"] == autoencoder
+        assert selected_models["autoencoder_version"] == auto_version
+        assert selected_models["dimred"] == dimred
+        assert selected_models["dimred_version"] == dimred_version
+        
+        # Verify data_project_dict at index 1 contains live_models
+        data_proj = results[1]
+        assert "live_models" in data_proj
+        assert data_proj["live_models"] == selected_models
 
     def test_update_live_models_failure(
         self, mock_redis_store, mock_live_mode_mlflow_client, mock_logger
@@ -131,6 +155,8 @@ class TestModelCallbacks:
         n_clicks = 1
         autoencoder = "test_autoencoder"
         dimred = "test_dimred"
+        auto_version = "2"
+        dimred_version = "1"
         data_project_dict = {"root_uri": "", "datasets": []}
 
         # Configure Redis failure
@@ -143,14 +169,12 @@ class TestModelCallbacks:
         ):
 
             results = update_live_models(
-                n_clicks, autoencoder, dimred, data_project_dict
+                n_clicks, autoencoder, auto_version, dimred, dimred_version, data_project_dict
             )
 
-        # Verify error handling
-        assert results[2] == "danger"  # Button color should indicate error
-        assert (
-            results[3] == "Update Fail"
-        )  # Button text should match actual implementation
+        # Verify error handling - index 2 is button color, index 3 is button text
+        assert results[2] == "danger"  # Button color
+        assert results[3] == "Update Fail"  # Button text
 
         # Verify logger was called with error
         mock_logger.error.assert_called()
@@ -160,27 +184,40 @@ class TestModelCallbacks:
         # Setup
         autoencoder = "test_autoencoder"
         dimred = "test_dimred"
-        selected_models = {"autoencoder": "old_autoencoder", "dimred": "old_dimred"}
+        auto_version = "3"
+        dimred_version = "2"
+        selected_models = {
+            "autoencoder": "old_autoencoder",
+            "dimred": "old_dimred",
+            "autoencoder_version": "1",
+            "dimred_version": "1"
+        }
 
         # Configure compatibility check
         mock_live_mode_mlflow_client.check_model_compatibility.return_value = True
 
-        # Execute - models changed
+        # Execute - models changed (different from selected_models)
         result_disabled, result_color, result_text = reset_update_button(
-            autoencoder, dimred, selected_models
+            autoencoder, auto_version, dimred, dimred_version, selected_models
         )
 
-        # Verify - button should be enabled with primary color
+        # Verify - button should be enabled when models differ
         assert result_disabled is False
         assert result_color == "primary"
         assert result_text == "Update Models"
 
-        # Execute - models unchanged
+        # Execute - models unchanged (same name and version)
+        selected_models_same = {
+            "autoencoder": "test_autoencoder",
+            "dimred": "test_dimred",
+            "autoencoder_version": "3",
+            "dimred_version": "2"
+        }
         result_disabled, result_color, result_text = reset_update_button(
-            "old_autoencoder", "old_dimred", selected_models
+            autoencoder, auto_version, dimred, dimred_version, selected_models_same
         )
 
-        # Verify - button should be disabled with secondary color
+        # Verify - button should be disabled when nothing changed
         assert result_disabled is True
         assert result_color == "secondary"
         assert result_text == "Updated"
@@ -188,7 +225,7 @@ class TestModelCallbacks:
         # Execute - incompatible models
         mock_live_mode_mlflow_client.check_model_compatibility.return_value = False
         result_disabled, result_color, result_text = reset_update_button(
-            "incompatible", dimred, selected_models
+            "incompatible", auto_version, dimred, dimred_version, selected_models
         )
 
         # Verify - based on actual implementation behavior

--- a/src/test/test_redis_store.py
+++ b/src/test/test_redis_store.py
@@ -11,10 +11,10 @@ from src.test.test_utils import mock_redis_client, redis_test_store
 class TestRedisStore:
 
     def test_store_and_get_models(self, redis_test_store):
-        """Test storing and retrieving model names"""
-        # Test data
-        autoencoder_name = "test_autoencoder_model"
-        dimred_name = "test_dimred_model"
+        """Test storing and retrieving model names with versions"""
+        # Test data - now with version format
+        autoencoder_name = "test_autoencoder_model:3"
+        dimred_name = "test_dimred_model:2"
 
         # Configure mock to return our test data
         redis_test_store._mock_client.get.side_effect = [autoencoder_name, dimred_name]
@@ -47,9 +47,9 @@ class TestRedisStore:
         )
 
     def test_publish_model_update(self, redis_test_store):
-        """Test pub/sub functionality"""
+        """Test pub/sub functionality with versions"""
         model_type = "autoencoder"
-        model_name = "new_model"
+        model_name = "new_model:5"
 
         # Mock publish to return 1 (one client received the message)
         redis_test_store._mock_client.publish.return_value = 1

--- a/src/test/test_reducer.py
+++ b/src/test/test_reducer.py
@@ -38,11 +38,11 @@ class TestReducer:
 
         # Create real numpy arrays with proper dimensions and types
         latent_features = np.random.rand(1, 64).astype(np.float32)
-        umap_coords = np.random.rand(1, 2).astype(np.float32)
+        dimred_coords = np.random.rand(1, 2).astype(np.float32)  # CHANGED: umap_coords -> dimred_coords
 
         # Set up the mocks to return real numpy arrays
         mocks["autoencoder"].predict.return_value = {"latent_features": latent_features}
-        mocks["dimred"].predict.return_value = {"umap_coords": umap_coords}
+        mocks["dimred"].predict.return_value = {"coords": dimred_coords}  # CHANGED: "umap_coords" -> "coords"
 
         # Set the models
         reducer.current_torch_model = mocks["autoencoder"]
@@ -61,11 +61,11 @@ class TestReducer:
         # 2. The dimred model should be called with the latent features
         mocks["dimred"].predict.assert_called_once_with(latent_features)
 
-        # 3. The result should be the actual numpy array from the mocked umap_coords
+        # 3. The result should be the actual numpy array from the mocked dimred_coords
         assert isinstance(result, np.ndarray)
-        assert result.shape == (1, 2)  # Check expected shape of UMAP coordinates
+        assert result.shape == (1, 2)  # Check expected shape of dimensionality reduction coordinates
         # Verify it's actually the same array we created
-        np.testing.assert_array_equal(result, umap_coords)
+        np.testing.assert_array_equal(result, dimred_coords)  # CHANGED: umap_coords -> dimred_coords
         
         # 4. Verify timing info is returned
         assert isinstance(timing_info, dict)

--- a/src/test/test_reducer.py
+++ b/src/test/test_reducer.py
@@ -92,7 +92,7 @@ class TestReducer:
         reducer.current_dim_reduction_model.predict.assert_not_called()
 
     def test_init_loads_models_from_redis(self):
-        """Test that constructor loads models from Redis"""
+        """Test that constructor loads models from Redis with version support"""
         # Create mocks for dependencies
         with (
             patch(
@@ -105,11 +105,11 @@ class TestReducer:
             patch("src.arroyo_reduction.reducer.logger"),
         ):
 
-            # Set up mock store - important to do this before importing
+            # Set up mock store - return identifiers with versions
             mock_store = MagicMock()
             redis_class_mock.return_value = mock_store
-            mock_store.get_autoencoder_model.return_value = "test_autoencoder"
-            mock_store.get_dimred_model.return_value = "test_dimred"
+            mock_store.get_autoencoder_model.return_value = "test_autoencoder:3"
+            mock_store.get_dimred_model.return_value = "test_dimred:2"
 
             # Set up mock MLflowClient
             mock_mlflow_client = MagicMock()
@@ -119,19 +119,19 @@ class TestReducer:
             mock_autoencoder = MagicMock()
             mock_dimred = MagicMock()
 
-            # Configure the load_model method
-            mock_mlflow_client.load_model.side_effect = lambda name: (
-                mock_autoencoder if name == "test_autoencoder" else mock_dimred
-            )
+            # Configure the load_model method to handle version parameter
+            def load_model_side_effect(name, version=None):
+                if 'autoencoder' in name:
+                    return mock_autoencoder
+                return mock_dimred
+            
+            mock_mlflow_client.load_model.side_effect = load_model_side_effect
 
             # Import the real class - this needs to be done AFTER setting up the mocks
-            # to ensure the imports in the module use our mocked objects
             import sys
-
             if "src.arroyo_reduction.reducer" in sys.modules:
                 del sys.modules["src.arroyo_reduction.reducer"]
 
-            # Now import the module fresh
             from src.arroyo_reduction.reducer import LatentSpaceReducer
 
             # Create the reducer
@@ -147,16 +147,24 @@ class TestReducer:
             # Verify MLflowClient was instantiated
             mlflow_client_mock.assert_called()
 
-            # Verify models were loaded
-            mock_mlflow_client.load_model.assert_any_call("test_autoencoder")
-            mock_mlflow_client.load_model.assert_any_call("test_dimred")
+            # Verify models were loaded with parsed version
+            assert mock_mlflow_client.load_model.call_count == 2
+            calls = mock_mlflow_client.load_model.call_args_list
+            
+            # First call should be autoencoder with version='3'
+            assert calls[0][0][0] == "test_autoencoder"
+            assert calls[0][1]['version'] == '3'
+            
+            # Second call should be dimred with version='2'
+            assert calls[1][0][0] == "test_dimred"
+            assert calls[1][1]['version'] == '2'
 
             # Verify loading flags are set correctly during initialization
             assert not reducer.is_loading_model
             assert reducer.loading_model_type is None
 
     def test_handle_model_update(self):
-        """Test handling model update notifications"""
+        """Test handling model update notifications with version support"""
         # Set up mock models
         mock_orig_autoencoder = MagicMock()
         mock_new_autoencoder = MagicMock()
@@ -173,29 +181,32 @@ class TestReducer:
                 "src.arroyo_reduction.reducer.LatentSpaceReducer._subscribe_to_model_updates"
             ),
             patch("src.arroyo_reduction.reducer.logger"),
-        ):  # Add logger patch to suppress errors
+        ):
 
             # Configure MLflowClient mock
             mock_mlflow_client = MagicMock()
             mlflow_client_mock.return_value = mock_mlflow_client
 
-            # Configure load_model to return different models based on name
-            mock_mlflow_client.load_model.side_effect = lambda name: {
-                "test_autoencoder": mock_orig_autoencoder,
-                "new_autoencoder": mock_new_autoencoder,
-                "test_dimred": mock_orig_dimred,
-                "new_dimred": mock_new_dimred,
-            }.get(name, MagicMock())
+            # Configure load_model to return different models and handle version parameter
+            def load_model_side_effect(name, version=None):
+                model_map = {
+                    "test_autoencoder": mock_orig_autoencoder,
+                    "new_autoencoder": mock_new_autoencoder,
+                    "test_dimred": mock_orig_dimred,
+                    "new_dimred": mock_new_dimred,
+                }
+                return model_map.get(name, MagicMock())
+            
+            mock_mlflow_client.load_model.side_effect = load_model_side_effect
 
-            # Set up mock store
+            # Set up mock store - return identifiers without versions for initial load
             mock_store = MagicMock()
             redis_mock.return_value = mock_store
             mock_store.get_autoencoder_model.return_value = "test_autoencoder"
             mock_store.get_dimred_model.return_value = "test_dimred"
 
-            # Import the real class - ensure we have a fresh import
+            # Import the real class
             import sys
-
             if "src.arroyo_reduction.reducer" in sys.modules:
                 del sys.modules["src.arroyo_reduction.reducer"]
 
@@ -211,43 +222,46 @@ class TestReducer:
             assert reducer.autoencoder_model_name == "test_autoencoder"
             assert reducer.dimred_model_name == "test_dimred"
 
-            # Create update messages
+            # Create update message with version in identifier
             autoencoder_update = {
                 "model_type": "autoencoder",
-                "model_name": "new_autoencoder",
+                "model_name": "new_autoencoder:5",
             }
 
             # Handle autoencoder update
             reducer._handle_model_update(autoencoder_update)
 
-            # Verify model name was updated
-            assert reducer.autoencoder_model_name == "new_autoencoder"
+            # Verify model name was updated with version
+            assert reducer.autoencoder_model_name == "new_autoencoder:5"
 
-            # Verify the mlflow_client.load_model was called with the new name
-            mock_mlflow_client.load_model.assert_any_call("new_autoencoder")
+            # Verify load_model was called with parsed name and version
+            mock_mlflow_client.load_model.assert_any_call("new_autoencoder", version="5")
 
-            # Create update for dimred model
-            dimred_update = {"model_type": "dimred", "model_name": "new_dimred"}
+            # Create update for dimred model with version
+            dimred_update = {
+                "model_type": "dimred", 
+                "model_name": "new_dimred:3"
+            }
 
             # Handle dimred update
             reducer._handle_model_update(dimred_update)
 
-            # Verify dimred model name was updated
-            assert reducer.dimred_model_name == "new_dimred"
+            # Verify dimred model name was updated with version
+            assert reducer.dimred_model_name == "new_dimred:3"
 
-            # Verify mlflow_client.load_model was called with the new dimred name
-            mock_mlflow_client.load_model.assert_any_call("new_dimred")
+            # Verify load_model was called with parsed name and version
+            mock_mlflow_client.load_model.assert_any_call("new_dimred", version="3")
 
             # Test with invalid update
             invalid_update = {"model_type": "unknown", "model_name": "test"}
             reducer._handle_model_update(invalid_update)
 
             # Verify no changes with invalid update
-            assert reducer.autoencoder_model_name == "new_autoencoder"
-            assert reducer.dimred_model_name == "new_dimred"
+            assert reducer.autoencoder_model_name == "new_autoencoder:5"
+            assert reducer.dimred_model_name == "new_dimred:3"
 
     def test_handle_duplicate_model_update(self):
-        """Test handling duplicate model update notifications"""
+        """Test handling duplicate model update notifications with version"""
         # Create the patch for MLflowClient and redis before importing anything
         with (
             patch("src.utils.mlflow_utils.MLflowClient") as mlflow_client_mock,
@@ -257,39 +271,39 @@ class TestReducer:
             patch(
                 "src.arroyo_reduction.reducer.LatentSpaceReducer._subscribe_to_model_updates"
             ),
+            patch("src.arroyo_reduction.reducer.logger"),
         ):
 
             # Configure MLflowClient mock
             mock_mlflow_client = MagicMock()
             mlflow_client_mock.return_value = mock_mlflow_client
 
-            # Set up mock store
+            # Set up mock store - return identifiers with versions
             mock_store = MagicMock()
             redis_mock.return_value = mock_store
-            mock_store.get_autoencoder_model.return_value = "test_autoencoder"
-            mock_store.get_dimred_model.return_value = "test_dimred"
+            mock_store.get_autoencoder_model.return_value = "test_autoencoder:3"
+            mock_store.get_dimred_model.return_value = "test_dimred:2"
 
-            # Import the real class - ensure we have a fresh import
+            # Import the real class
             import sys
-
             if "src.arroyo_reduction.reducer" in sys.modules:
                 del sys.modules["src.arroyo_reduction.reducer"]
 
             from src.arroyo_reduction.reducer import LatentSpaceReducer
 
-            # Create the reducer - which loads the initial models
+            # Create the reducer
             reducer = LatentSpaceReducer()
 
-            # Add mlflow_client attribute with load_model method
+            # Add mlflow_client attribute
             reducer.mlflow_client = mock_mlflow_client
 
-            # Reset mock_mlflow_client to clear call history
+            # Reset mock to clear call history
             mock_mlflow_client.reset_mock()
 
-            # Create duplicate update message (same as current model)
+            # Create duplicate update with version (same as current)
             duplicate_update = {
                 "model_type": "autoencoder",
-                "model_name": "test_autoencoder",  # Same as current model
+                "model_name": "test_autoencoder:3",
             }
 
             # Track the initial state
@@ -306,13 +320,6 @@ class TestReducer:
 
             # 2. Most importantly, load_model should NOT be called for duplicates
             mock_mlflow_client.load_model.assert_not_called()
-
-            # Verify the model was NOT reloaded
-            mock_mlflow_client.load_model.assert_not_called()
-
-            # Verify model names were not changed
-            assert reducer.autoencoder_model_name == "test_autoencoder"
-            assert reducer.dimred_model_name == "test_dimred"
 
     def test_loading_flags_during_model_update(self):
         """Test that loading flags are set and reset correctly during model update"""
@@ -347,8 +354,8 @@ class TestReducer:
             # Add mlflow_client attribute
             reducer.mlflow_client = mock_mlflow_client
 
-            # Create test update message
-            update = {"model_type": "autoencoder", "model_name": "new_autoencoder"}
+            # Create test update message (can include version)
+            update = {"model_type": "autoencoder", "model_name": "new_autoencoder:7"}
 
             # Mock the flags to verify they're being set correctly
             reducer.is_loading_model = False

--- a/src/test/test_vector_save.py
+++ b/src/test/test_vector_save.py
@@ -19,13 +19,13 @@ async def test_vector_save_listener(tmp_path):
     # Current timestamp for testing
     current_time = time.time()
     
-    # Simulate a message with timing data
+    # Simulate a message with timing data and versions
     message = {
         "tiled_url": "http://example.com/image1.jpg",
         "feature_vector": [1, 2],
         "index": 0,
-        "autoencoder_model": "model_v1",
-        "dimred_model": "model_v2",
+        "autoencoder_model": "model_v1:3",  # ← CHANGED: added version
+        "dimred_model": "model_v2:2",        # ← CHANGED: added version
         "timestamp": current_time,
         "total_processing_time": 0.1234,
         "autoencoder_time": 0.0789,
@@ -54,8 +54,8 @@ async def test_vector_save_listener(tmp_path):
             assert len(rows) == 1
             assert rows[0][0] == message.tiled_url
             assert rows[0][1] == json.dumps(message.feature_vector)
-            assert rows[0][2] == message.autoencoder_model
-            assert rows[0][3] == message.dimred_model
+            assert rows[0][2] == message.autoencoder_model  # Now contains "model_v1:3"
+            assert rows[0][3] == message.dimred_model        # Now contains "model_v2:2"
             assert rows[0][4] == current_time
             assert rows[0][5] == 0.1234
             assert rows[0][6] == 0.0789

--- a/src/utils/data_utils.py
+++ b/src/utils/data_utils.py
@@ -89,31 +89,43 @@ def hash_list_of_strings(strings_list):
     return humanize(digest)
 
 
+# ============= UPDATED/NEW FUNCTIONS FOR USER HIERARCHY =============
+
 def get_daily_containers():
     """
-    Retrieve all available daily containers from Tiled
+    Retrieve all available daily containers for the current user from Tiled
     
     Returns:
         list: List of dictionaries with {label: container_name, value: container_name}
     """
     try:
+        # Get username from environment
+        username = os.getenv("USER", "default_user")
+        
         # Check if tiled_results client is available
         if not tiled_results.check_dataloader_ready():
             logger.warning("Tiled results client not available")
             return []
         
-        # Get the daily run container
+        # Get the root container
         container = tiled_results.data_client
         
-        # Navigate to the lse_live_results path
+        # Navigate to the lse_live_results/username path
         if "lse_live_results" in container:
             container = container["lse_live_results"]
             
+            # Check if user container exists
+            if username not in container:
+                logger.warning(f"User {username} not found in lse_live_results")
+                return []
+            
+            user_container = container[username]
+            
             # Find all daily run containers and sort in reverse chronological order
-            daily_runs = sorted([k for k in container.keys() if k.startswith("daily_run_")], reverse=True)
+            daily_runs = sorted([k for k in user_container.keys() if k.startswith("daily_run_")], reverse=True)
             
             if not daily_runs:
-                logger.warning("No daily run containers found")
+                logger.warning(f"No daily run containers found for user {username}")
                 return []
                 
             # Format as dropdown options with human-readable labels
@@ -127,6 +139,7 @@ def get_daily_containers():
         logger.error(f"Error retrieving daily containers: {e}")
         return []
 
+
 def format_container_name(container_name):
     """Format a container name for display in the dropdown"""
     if container_name.startswith("daily_run_"):
@@ -135,10 +148,10 @@ def format_container_name(container_name):
         return f"Daily Run {date_str}"
     return container_name
 
-# These functions support the new 3-level hierarchy: daily_container/experiment_name/uuid
+
 def get_experiment_names_in_container(container_name):
     """
-    Retrieve all available experiment names from a specific daily container
+    Retrieve all available experiment names from a specific daily container for the current user
     
     Args:
         container_name (str): The name of the daily container (e.g., "daily_run_2025-08-20")
@@ -147,45 +160,54 @@ def get_experiment_names_in_container(container_name):
         list: List of dictionaries with {label: experiment_name, value: experiment_name}
     """
     try:
+        # Get username from environment
+        username = os.getenv("USER", "default_user")
+        
         # Check if tiled_results client is available
         if not tiled_results.check_dataloader_ready():
             logger.warning("Tiled results client not available")
             return []
         
-        # Get the daily run container
+        # Get the root container
         container = tiled_results.data_client
         
-        # Navigate to the lse_live_results/container_name path
+        # Navigate to the lse_live_results/username/container_name path
         if "lse_live_results" not in container:
             logger.warning("lse_live_results container not found")
             return []
             
         container = container["lse_live_results"]
         
-        if container_name not in container:
-            logger.warning(f"Container {container_name} not found")
+        if username not in container:
+            logger.warning(f"User {username} not found")
+            return []
+        
+        user_container = container[username]
+        
+        if container_name not in user_container:
+            logger.warning(f"Container {container_name} not found for user {username}")
             return []
             
-        daily_container = container[container_name]
+        daily_container = user_container[container_name]
         
         # Get all experiment names (containers) in this daily container
         experiment_names = [key for key in daily_container.keys()]
         
         if not experiment_names:
-            logger.warning(f"No experiment names found in container {container_name}")
+            logger.warning(f"No experiment names found in {username}/{container_name}")
             return []
         
         # Format as dropdown options
         return [{"label": name, "value": name} for name in experiment_names]
             
     except Exception as e:
-        logger.error(f"Error retrieving experiment names from container {container_name}: {e}")
+        logger.error(f"Error retrieving experiment names from {container_name}: {e}")
         return []
 
 
 def get_uuids_in_experiment(container_name, experiment_name):
     """
-    Retrieve all available experiment UUIDs from a specific experiment
+    Retrieve all available experiment UUIDs from a specific experiment for the current user
     
     Args:
         container_name (str): The name of the daily container (e.g., "daily_run_2025-08-20")
@@ -195,29 +217,38 @@ def get_uuids_in_experiment(container_name, experiment_name):
         list: List of dictionaries with {label: uuid, value: uuid}
     """
     try:
+        # Get username from environment
+        username = os.getenv("USER", "default_user")
+        
         # Check if tiled_results client is available
         if not tiled_results.check_dataloader_ready():
             logger.warning("Tiled results client not available")
             return []
         
-        # Get the daily run container
+        # Get the root container
         container = tiled_results.data_client
         
-        # Navigate to the lse_live_results/container_name/experiment_name path
+        # Navigate to the lse_live_results/username/container_name/experiment_name path
         if "lse_live_results" not in container:
             logger.warning("lse_live_results container not found")
             return []
             
         container = container["lse_live_results"]
         
-        if container_name not in container:
-            logger.warning(f"Container {container_name} not found")
+        if username not in container:
+            logger.warning(f"User {username} not found")
+            return []
+        
+        user_container = container[username]
+        
+        if container_name not in user_container:
+            logger.warning(f"Container {container_name} not found for user {username}")
             return []
             
-        daily_container = container[container_name]
+        daily_container = user_container[container_name]
         
         if experiment_name not in daily_container:
-            logger.warning(f"Experiment {experiment_name} not found in {container_name}")
+            logger.warning(f"Experiment {experiment_name} not found in {username}/{container_name}")
             return []
         
         experiment_container = daily_container[experiment_name]
@@ -226,7 +257,7 @@ def get_uuids_in_experiment(container_name, experiment_name):
         uuids = list(experiment_container.keys())
         
         if not uuids:
-            logger.warning(f"No UUIDs found in {container_name}/{experiment_name}")
+            logger.warning(f"No UUIDs found in {username}/{container_name}/{experiment_name}")
             return []
         
         # Format as dropdown options
@@ -235,3 +266,71 @@ def get_uuids_in_experiment(container_name, experiment_name):
     except Exception as e:
         logger.error(f"Error retrieving UUIDs from {container_name}/{experiment_name}: {e}")
         return []
+
+
+def get_experiment_dataframe(container_name, experiment_name, uuid):
+    """
+    Retrieve the DataFrame for a specific UUID from an experiment
+    
+    Args:
+        container_name (str): The name of the daily container (e.g., "daily_run_2025-08-20")
+        experiment_name (str): The name of the experiment
+        uuid (str): The UUID of the specific table to retrieve
+        
+    Returns:
+        pandas.DataFrame or None: The DataFrame containing the experiment data, or None if not found
+    """
+    try:
+        # Get username from environment
+        username = os.getenv("USER", "default_user")
+        
+        # Check if tiled_results client is available
+        if not tiled_results.check_dataloader_ready():
+            logger.warning("Tiled results client not available")
+            return None
+        
+        # Get the root container
+        container = tiled_results.data_client
+        
+        # Navigate to the lse_live_results/username/container_name/experiment_name path
+        if "lse_live_results" not in container:
+            logger.warning("lse_live_results container not found")
+            return None
+            
+        container = container["lse_live_results"]
+        
+        if username not in container:
+            logger.warning(f"User {username} not found")
+            return None
+        
+        user_container = container[username]
+        
+        if container_name not in user_container:
+            logger.warning(f"Container {container_name} not found for user {username}")
+            return None
+            
+        daily_container = user_container[container_name]
+        
+        if experiment_name not in daily_container:
+            logger.warning(f"Experiment {experiment_name} not found in {username}/{container_name}")
+            return None
+        
+        experiment_container = daily_container[experiment_name]
+        
+        if uuid not in experiment_container:
+            logger.warning(f"UUID {uuid} not found in {username}/{container_name}/{experiment_name}")
+            return None
+        
+        # Get and return the DataFrame
+        df = experiment_container[uuid].read()
+        
+        if df is not None and not df.empty:
+            logger.info(f"Successfully loaded DataFrame with shape {df.shape} from {username}/{container_name}/{experiment_name}/{uuid}")
+        else:
+            logger.warning(f"DataFrame is empty for {username}/{container_name}/{experiment_name}/{uuid}")
+            
+        return df
+        
+    except Exception as e:
+        logger.error(f"Error retrieving DataFrame from {container_name}/{experiment_name}/{uuid}: {e}")
+        return None


### PR DESCRIPTION
The “frame” ingested by the LSE corresponds to the “shot” heatmap published by the XPS operator. Currently, the XPS code sends this data over a WebSocket, along with several other metadata fields, while the LSE receives its input via Tiled.

Dylan outlined three possible ways to bridge this gap:

- In XPS: create a ZMQ frame publisher.
- In LSE: implement a WebSocket listener that consumes the messages produced by the XPS code.
- In XPS: publish the frames to Tiled, and in LSE: read them from Tiled as they arrive.

This PR implements a draft solution for option 2.

1. Implements XPSWebSocketListener to handle messages sent by the XPS WebSocket ([link](https://github.com/als-computing/ArroyoXPS/blob/d74a5f96b6a423010022136dc72d77a4f10814d5/src/tr_ap_xps/websockets.py#L146)).

2. Implements XPSTiledLocalImagePublisher. Once the data is received from the WebSocket, a RawFrameEvent is sent. When the operator receives this event, it invokes the publisher to upload the data to the local Tiled server (e.g. `{tiled_base_uri}/api/v1/array/full/beamlines/bl931/processed/live_data_cache/{current_uuid}/xps_averaged_heatmaps/frame_{shot_num}?slice=0:1,0:{height},0:{width}`).

Companion PR: https://github.com/als-computing/arroyosas/pull/20