### PR TITLE
update to match arroyosas

### DIFF
--- a/block_configs/lse_sas_operator_block.yaml
+++ b/block_configs/lse_sas_operator_block.yaml
@@ -6,9 +6,9 @@ blocks:
       class: src.arroyo_reduction.operator.build_lse_operator
 
     listeners:
-      - class: arroyosas.zmq.ZMQFrameListener
+      - class: arroyosas.zmq.create_zmq_frame_listener
         kwargs:
-          address: "tcp://sim_unified:5000"
+          zmq_address: "tcp://sim_unified:5000"
 
     publishers:
       - class: src.arroyo_reduction.publisher.lse_ws_result_publisher_factory

--- a/live_operator_example/mlflow_config.yaml
+++ b/live_operator_example/mlflow_config.yaml
@@ -1,6 +1,6 @@
 # Common settings
 common:
-  dataset: "timepix"  # "smi" or "trs" - determines which dataset config to use
+  dataset: "smi"  # "smi" or "trs" - determines which dataset config to use
   autoencoder_type: "VAE"  # use VIT or VAE
   dimred_type: "neural" #use joblib or neural
 


### PR DESCRIPTION
Updated the code to be compatible with the latest Arroyosas implementation, which uses `create_zmq_frame_listener` to create listeners.
