### PR TITLE
Xiaoya add mlflow env

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,9 @@ There are two main types of simulators available:
 ```sh
 source .env
 cd live_operator_example
+conda create -n mlflow_client python==3.11
+conda activate mlflow_client
+pip install -r requirements.txt
 python save_mlflow_wrapper.py
 ```
 

--- a/block_configs/lse_sas_operator_block.yaml
+++ b/block_configs/lse_sas_operator_block.yaml
@@ -6,9 +6,9 @@ blocks:
       class: src.arroyo_reduction.operator.build_lse_operator
 
     listeners:
-      - class: arroyosas.zmq.ZMQFrameListener
+      - class: arroyosas.zmq.create_zmq_frame_listener
         kwargs:
-          address: "tcp://sim_unified:5000"
+          zmq_address: "tcp://sim_unified:5000"
 
     publishers:
       - class: src.arroyo_reduction.publisher.lse_ws_result_publisher_factory

--- a/live_operator_example/mlflow_config.yaml
+++ b/live_operator_example/mlflow_config.yaml
@@ -1,6 +1,6 @@
 # Common settings
 common:
-  dataset: "timepix"  # "smi" or "trs" - determines which dataset config to use
+  dataset: "smi"  # "smi" or "trs" - determines which dataset config to use
   autoencoder_type: "VAE"  # use VIT or VAE
   dimred_type: "neural" #use joblib or neural
 

--- a/live_operator_example/requirements.txt
+++ b/live_operator_example/requirements.txt
@@ -1,0 +1,23 @@
+# Core MLflow
+mlflow==2.22.0
+cryptography==41.0.7
+
+# PyTorch - for VAE/ViT wrappers
+torch==2.2.2
+torchvision
+
+# Image processing - for VAE/ViT predict()
+Pillow
+
+# Numerical
+numpy==1.26.4
+scipy==1.15.1
+scikit-learn==1.6.1
+joblib==1.4.2
+numba==0.61.0
+umap-learn==0.5.7
+
+
+# Config / env
+python-dotenv
+pyyaml


### PR DESCRIPTION
When registering the model to `MLflow`, we need a `Conda` environment for the registration process. I found that the package versions are tricky and need to be compatible with each other when registering the `.joblib` model to MLflow. Therefore, I created a `requirements.txt` file and updated the `README` with the environment setup instructions.
